### PR TITLE
[codex] Add top voted board topics

### DIFF
--- a/apps/web/src/app/app.component.ts
+++ b/apps/web/src/app/app.component.ts
@@ -42,6 +42,7 @@ export class AppComponent {
     'search',
     'text',
     'token',
+    'top-voted',
     'voting',
     'google',
     'user',

--- a/apps/web/src/app/modules/board/board/board.component.scss
+++ b/apps/web/src/app/modules/board/board/board.component.scss
@@ -63,7 +63,6 @@ tapiz-board-toolbar {
   left: 1rem;
   position: fixed;
   top: 50%;
-  transform: translateY(-50%);
   z-index: var(--board-tools-layer);
 }
 

--- a/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.html
+++ b/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.html
@@ -74,6 +74,7 @@
 
   @if (boardMode() === 0) {
     <ng-container [ngTemplateOutlet]="voteButton"></ng-container>
+    <ng-container [ngTemplateOutlet]="topVotedButton"></ng-container>
   }
 
   <ng-container [ngTemplateOutlet]="tokenButton"></ng-container>
@@ -151,6 +152,9 @@
           }
           @case ('live-reaction') {
             <tapiz-live-reaction (reactionSelected)="reactionSelected()" />
+          }
+          @case ('top-voted') {
+            <tapiz-top-voted />
           }
           @case ('image') {
             <tapiz-add-image
@@ -234,6 +238,16 @@
     label="Vote"
     [active]="popup() === 'vote'"
     (clicked)="vote()">
+  </tapiz-board-toolbar-button>
+</ng-template>
+
+<ng-template #topVotedButton>
+  <tapiz-board-toolbar-button
+    icon="top-voted"
+    tooltip="Top voted"
+    label="Top voted"
+    [active]="popup() === 'top-voted'"
+    (clicked)="togglePopup('top-voted')">
   </tapiz-board-toolbar-button>
 </ng-template>
 

--- a/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.scss
+++ b/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.scss
@@ -22,10 +22,14 @@
   padding: var(--size-2);
   transition: background 0.5s ease;
   backdrop-filter: blur(90px);
+  transform: translateY(-50%);
 }
 
 .toolbar-container {
+  display: flex;
+  max-block-size: calc(100vh - 2rem);
   padding-inline-start: var(--spacing-2);
+  transform: translateY(-50%);
 }
 
 hr {
@@ -43,6 +47,8 @@ hr {
   border-radius: var(--radius-3);
   padding: var(--spacing-4);
   box-shadow: 0 0 15px 3px rgba(66, 62, 82, 0.1);
+  max-block-size: inherit;
+  overflow-y: auto;
 }
 
 .toolbar-pinned {

--- a/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.ts
+++ b/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.ts
@@ -50,6 +50,7 @@ import { BoardToolbardButtonComponent } from './components/board-toolboard-butto
 import { LucideAngularModule, Pin, PinOff } from 'lucide-angular';
 import { ArrowToolbarComponent } from '../arrows/arrow-toolbar/arrow-toolbar.component';
 import { PingStore } from '../ping/ping.store';
+import { TopVotedComponent } from '../top-voted/top-voted.component';
 
 export class AppModule {}
 @Component({
@@ -68,6 +69,7 @@ export class AppModule {}
     CocomaterialComponent,
     NotesComponent,
     ToolsComponent,
+    TopVotedComponent,
     NgTemplateOutlet,
     BoardToolbardButtonComponent,
     LucideAngularModule,
@@ -105,6 +107,7 @@ export class BoardToolbarComponent {
       'templates',
       'cocomaterial',
       'live-reaction',
+      'top-voted',
       'image',
     ];
 
@@ -119,6 +122,7 @@ export class BoardToolbarComponent {
       'templates',
       'cocomaterial',
       'live-reaction',
+      'top-voted',
       'image',
     ];
 

--- a/apps/web/src/app/modules/board/components/top-voted/top-voted.component.scss
+++ b/apps/web/src/app/modules/board/components/top-voted/top-voted.component.scss
@@ -1,0 +1,114 @@
+:host {
+  display: block;
+  inline-size: min(560px, calc(100vw - 120px));
+}
+.top-voted {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-3);
+}
+header {
+  align-items: center;
+  border-block-end: 1px solid var(--grey-30);
+  display: flex;
+  justify-content: space-between;
+  padding-block-end: var(--spacing-3);
+  h2,
+  p {
+    margin: 0;
+  }
+  h2 {
+    font-size: var(--font-size-4);
+  }
+  p {
+    color: var(--grey-70);
+    font-size: var(--font-size-0);
+  }
+}
+ol {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  list-style: none;
+  margin: 0;
+  max-block-size: min(560px, calc(100vh - 240px));
+  overflow-y: auto;
+  padding: 0;
+}
+li button {
+  align-items: start;
+  background: var(--white);
+  block-size: auto;
+  border: 1px solid var(--grey-30);
+  border-radius: var(--radius-2);
+  cursor: pointer;
+  display: grid;
+  gap: var(--spacing-3);
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  inline-size: 100%;
+  min-block-size: 84px;
+  padding: var(--spacing-3);
+  text-align: start;
+
+  &:hover {
+    border-color: var(--primary-color-button-bg);
+  }
+}
+.rank {
+  align-items: center;
+  background: var(--primary-color-background);
+  border-radius: 50%;
+  color: var(--primary-color-button-bg);
+  display: flex;
+  font-weight: 700;
+  block-size: 32px;
+  inline-size: 32px;
+  justify-content: center;
+}
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-inline-size: 0;
+}
+.title {
+  color: var(--grey-90);
+  font-weight: 600;
+  line-height: 1.35;
+  white-space: normal;
+  word-break: break-word;
+}
+.meta {
+  color: var(--grey-70);
+  display: block;
+  font-size: var(--font-size-0);
+  line-height: 1.3;
+  white-space: nowrap;
+}
+.votes {
+  align-items: center;
+  align-self: start;
+  background: var(--primary-color-button-bg);
+  border-radius: var(--radius-2);
+  color: var(--white);
+  display: inline-flex;
+  font-weight: 700;
+  gap: 4px;
+  padding: 6px 8px;
+  mat-icon {
+    block-size: 16px;
+    font-size: 16px;
+    inline-size: 16px;
+  }
+}
+.empty {
+  align-items: center;
+  color: var(--grey-70);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  padding: var(--spacing-6);
+  p {
+    margin: 0;
+  }
+}

--- a/apps/web/src/app/modules/board/components/top-voted/top-voted.component.ts
+++ b/apps/web/src/app/modules/board/components/top-voted/top-voted.component.ts
@@ -1,0 +1,104 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from '@angular/core';
+import { Store } from '@ngrx/store';
+import { MatIconModule } from '@angular/material/icon';
+import { isNote } from '@tapiz/board-commons';
+import { BoardFacade } from '../../../../services/board-facade.service';
+import { BoardPageActions } from '../../actions/board-page.actions';
+import { boardPageFeature } from '../../reducers/boardPage.reducer';
+import { buildTopVotedItems } from './top-voted.utils';
+import type { TopVotedItem } from './top-voted.utils';
+
+@Component({
+  selector: 'tapiz-top-voted',
+  imports: [MatIconModule],
+  template: `
+    <section class="top-voted">
+      <header>
+        <div>
+          <h2>Top voted</h2>
+          <p>{{ topItems().length }} topics ready to discuss</p>
+        </div>
+      </header>
+
+      @if (topItems().length) {
+        <ol>
+          @for (item of topItems(); track item.id + item.type) {
+            <li>
+              <button
+                type="button"
+                (click)="goTo(item)">
+                <span class="rank">{{ $index + 1 }}</span>
+                <span class="content">
+                  <span class="title">{{ item.title }}</span>
+                  <span class="meta">
+                    {{ typeLabel(item) }}
+                    @if (item.type === 'panel') {
+                      · {{ item.containedItems }}
+                      {{ item.containedItems === 1 ? 'item' : 'items' }}
+                    }
+                  </span>
+                </span>
+                <span class="votes">
+                  <mat-icon>thumb_up</mat-icon>
+                  {{ item.votes }}
+                </span>
+              </button>
+            </li>
+          }
+        </ol>
+      } @else {
+        <div class="empty">
+          <mat-icon>how_to_vote</mat-icon>
+          <p>No votes yet</p>
+        </div>
+      }
+    </section>
+  `,
+  styleUrls: ['./top-voted.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TopVotedComponent {
+  #boardFacade = inject(BoardFacade);
+  #store = inject(Store);
+
+  #currentUserId = this.#store.selectSignal(boardPageFeature.selectUserId);
+
+  topItems = computed(() => {
+    const nodes = this.#boardFacade.nodes();
+    const users = this.#boardFacade.usersNodes();
+    const currentUserId = this.#currentUserId();
+    const visibleNoteOwnerIds = new Set<string>();
+
+    nodes.filter(isNote).forEach((note) => {
+      const user = users.find((user) => user.id === note.content.ownerId);
+
+      if (!user || user.id === currentUserId || user.content.visible) {
+        visibleNoteOwnerIds.add(note.content.ownerId);
+      }
+    });
+
+    return buildTopVotedItems(nodes, {
+      visibleNoteOwnerIds,
+    });
+  });
+
+  goTo(item: TopVotedItem) {
+    this.#store.dispatch(BoardPageActions.goToNode({ nodeId: item.id }));
+  }
+
+  typeLabel(item: TopVotedItem) {
+    switch (item.type) {
+      case 'group':
+        return 'Group';
+      case 'panel':
+        return 'Panel';
+      default:
+        return 'Note';
+    }
+  }
+}

--- a/apps/web/src/app/modules/board/components/top-voted/top-voted.utils.spec.ts
+++ b/apps/web/src/app/modules/board/components/top-voted/top-voted.utils.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import type { Group, Note, Panel, TuNode } from '@tapiz/board-commons';
+import { buildTopVotedItems, cleanNodeText, sumVotes } from './top-voted.utils';
+
+describe('top-voted utils', () => {
+  it('sums votes using the board vote semantics', () => {
+    expect(sumVotes([{ vote: 2 }, { vote: -1 }, { vote: 3 }])).toBe(4);
+  });
+
+  it('sorts visible notes and groups by vote count', () => {
+    const nodes: TuNode[] = [
+      note('note-low', 10, 10, 'user-1', '<p>Low</p>', 2),
+      group('group-high', 20, 20, 'High group', 5),
+      note('note-hidden', 30, 30, 'user-2', '<p>Hidden</p>', 10),
+    ];
+
+    expect(
+      buildTopVotedItems(nodes, {
+        visibleNoteOwnerIds: new Set(['user-1']),
+      }),
+    ).toEqual([
+      {
+        id: 'group-high',
+        type: 'group',
+        title: 'High group',
+        votes: 5,
+        containedItems: 1,
+      },
+      {
+        id: 'note-low',
+        type: 'note',
+        title: 'Low',
+        votes: 2,
+        containedItems: 1,
+      },
+    ]);
+  });
+
+  it('adds panel aggregate entries for voted items inside the panel', () => {
+    const nodes: TuNode[] = [
+      panel('panel-1', 0, 0, 500, 500, '<p>Keep</p>'),
+      note('note-1', 20, 20, 'user-1', '<p>Inside</p>', 3),
+      group('group-1', 1000, 1000, 'Outside', 4),
+    ];
+
+    expect(
+      buildTopVotedItems(nodes, {
+        visibleNoteOwnerIds: new Set(['user-1']),
+      }),
+    ).toContainEqual({
+      id: 'panel-1',
+      type: 'panel',
+      title: 'Keep',
+      votes: 3,
+      containedItems: 1,
+    });
+  });
+
+  it('cleans html text for compact result labels', () => {
+    expect(cleanNodeText('<p>Customer&nbsp;&amp;&nbsp;team</p>')).toBe(
+      'Customer & team',
+    );
+  });
+});
+
+function note(
+  id: string,
+  x: number,
+  y: number,
+  ownerId: string,
+  text: string,
+  vote: number,
+): TuNode<Note, 'note'> {
+  return {
+    id,
+    type: 'note',
+    content: {
+      text,
+      position: { x, y },
+      layer: 0,
+      ownerId,
+      votes: [{ userId: 'voter', vote }],
+      emojis: [],
+      drawing: [],
+      width: 200,
+      height: 100,
+    },
+  };
+}
+
+function group(
+  id: string,
+  x: number,
+  y: number,
+  title: string,
+  vote: number,
+): TuNode<Group, 'group'> {
+  return {
+    id,
+    type: 'group',
+    content: {
+      title,
+      position: { x, y },
+      layer: 0,
+      width: 200,
+      height: 100,
+      votes: [{ userId: 'voter', vote }],
+    },
+  };
+}
+
+function panel(
+  id: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  text: string,
+): TuNode<Panel, 'panel'> {
+  return {
+    id,
+    type: 'panel',
+    content: {
+      text,
+      position: { x, y },
+      layer: 0,
+      width,
+      height,
+      rotation: 0,
+      drawing: [],
+    },
+  };
+}

--- a/apps/web/src/app/modules/board/components/top-voted/top-voted.utils.ts
+++ b/apps/web/src/app/modules/board/components/top-voted/top-voted.utils.ts
@@ -1,0 +1,128 @@
+import {
+  isGroup,
+  isNote,
+  isPanel,
+  type Group,
+  type Note,
+  type Panel,
+  type TuNode,
+} from '@tapiz/board-commons';
+import { getNodeSize } from '../../../../shared/node-size';
+
+type VotableNode = TuNode<Note, 'note'> | TuNode<Group, 'group'>;
+type PanelNode = TuNode<Panel, 'panel'>;
+
+export type TopVotedItem = {
+  id: string;
+  type: 'note' | 'group' | 'panel';
+  title: string;
+  votes: number;
+  containedItems: number;
+};
+
+export function buildTopVotedItems(
+  nodes: TuNode[],
+  options: {
+    visibleNoteOwnerIds: Set<string>;
+    limit?: number;
+  },
+): TopVotedItem[] {
+  const limit = options.limit ?? 12;
+  const votableNodes = nodes
+    .filter((node): node is VotableNode => {
+      if (isNote(node)) {
+        return options.visibleNoteOwnerIds.has(node.content.ownerId);
+      }
+
+      return isGroup(node);
+    })
+    .map((node) => {
+      return {
+        node,
+        votes: sumVotes(node.content.votes),
+      };
+    })
+    .filter(({ votes }) => votes > 0);
+
+  const directItems = votableNodes.map(({ node, votes }) => {
+    return {
+      id: node.id,
+      type: node.type,
+      title: getNodeTitle(node),
+      votes,
+      containedItems: 1,
+    } satisfies TopVotedItem;
+  });
+
+  const panelItems = nodes
+    .filter((node): node is PanelNode => isPanel(node))
+    .map((panel) => {
+      const containedNodes = votableNodes.filter(({ node }) => {
+        return isNodeInsidePanel(node, panel);
+      });
+
+      return {
+        id: panel.id,
+        type: 'panel',
+        title: getNodeTitle(panel),
+        votes: containedNodes.reduce((total, item) => total + item.votes, 0),
+        containedItems: containedNodes.length,
+      } satisfies TopVotedItem;
+    })
+    .filter((item) => item.votes > 0);
+
+  return [...directItems, ...panelItems]
+    .toSorted((a, b) => {
+      if (b.votes !== a.votes) {
+        return b.votes - a.votes;
+      }
+
+      return a.title.localeCompare(b.title);
+    })
+    .slice(0, limit);
+}
+
+export function sumVotes(votes: { vote: number }[]) {
+  return votes.reduce((total, item) => total + item.vote, 0);
+}
+
+export function cleanNodeText(text: string) {
+  return text
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function getNodeTitle(node: VotableNode | PanelNode) {
+  if (isGroup(node)) {
+    return node.content.title.trim() || 'Untitled group';
+  }
+
+  const text = cleanNodeText(node.content.text);
+
+  if (text) {
+    return text;
+  }
+
+  return isNote(node) ? 'Untitled note' : 'Untitled panel';
+}
+
+function isNodeInsidePanel(node: VotableNode, panel: PanelNode) {
+  const nodeSize = getNodeSize(node);
+  const nodeCenter = {
+    x: node.content.position.x + nodeSize.width / 2,
+    y: node.content.position.y + nodeSize.height / 2,
+  };
+  const panelSize = getNodeSize(panel);
+
+  return (
+    nodeCenter.x >= panel.content.position.x &&
+    nodeCenter.x <= panel.content.position.x + panelSize.width &&
+    nodeCenter.y >= panel.content.position.y &&
+    nodeCenter.y <= panel.content.position.y + panelSize.height
+  );
+}

--- a/apps/web/src/app/modules/board/effects/board-page.effects.spec.ts
+++ b/apps/web/src/app/modules/board/effects/board-page.effects.spec.ts
@@ -1,0 +1,83 @@
+import { TestBed } from '@angular/core/testing';
+import { provideMockActions } from '@ngrx/effects/testing';
+import { MockStore, provideMockStore } from '@ngrx/store/testing';
+import { Action } from '@ngrx/store';
+import { Subject, firstValueFrom, of } from 'rxjs';
+import { catchError, take, timeout } from 'rxjs/operators';
+import { describe, expect, it, beforeEach } from 'vitest';
+import { ActivatedRoute } from '@angular/router';
+import { BoardFacade } from '../../../services/board-facade.service';
+import { BoardApiService } from '../../../services/board-api.service';
+import { BoardPageActions } from '../actions/board-page.actions';
+import { boardPageFeature } from '../reducers/boardPage.reducer';
+import { BoardPageEffects } from './board-page.effects';
+
+describe('BoardPageEffects', () => {
+  let actions$: Subject<Action>;
+  let effects: BoardPageEffects;
+  let store: MockStore;
+
+  beforeEach(() => {
+    actions$ = new Subject<Action>();
+
+    TestBed.configureTestingModule({
+      providers: [
+        BoardPageEffects,
+        provideMockActions(() => actions$),
+        provideMockStore(),
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              queryParams: {},
+            },
+          },
+        },
+        {
+          provide: BoardFacade,
+          useValue: {
+            nodes: () => [],
+            usersNodes: () => [],
+          },
+        },
+        {
+          provide: BoardApiService,
+          useValue: {},
+        },
+      ],
+    });
+
+    effects = TestBed.inject(BoardPageEffects);
+    store = TestBed.inject(MockStore);
+  });
+
+  it('keeps a pinned popup open when navigating to a node', async () => {
+    store.overrideSelector(boardPageFeature.selectPopupPinned, true);
+    store.refreshState();
+
+    const result = firstValueFrom(
+      effects.goToNoteResetPopup$.pipe(
+        take(1),
+        timeout({ first: 20 }),
+        catchError(() => of(null)),
+      ),
+    );
+
+    actions$.next(BoardPageActions.goToNode({ nodeId: 'note-1' }));
+
+    await expect(result).resolves.toBeNull();
+  });
+
+  it('closes an unpinned popup when navigating to a node', async () => {
+    store.overrideSelector(boardPageFeature.selectPopupPinned, false);
+    store.refreshState();
+
+    const result = firstValueFrom(effects.goToNoteResetPopup$.pipe(take(1)));
+
+    actions$.next(BoardPageActions.goToNode({ nodeId: 'note-1' }));
+
+    await expect(result).resolves.toEqual(
+      BoardPageActions.setPopupOpen({ popup: '' }),
+    );
+  });
+});

--- a/apps/web/src/app/modules/board/effects/board-page.effects.ts
+++ b/apps/web/src/app/modules/board/effects/board-page.effects.ts
@@ -67,6 +67,10 @@ export class BoardPageEffects {
   goToNoteResetPopup$ = createEffect(() => {
     return this.#actions$.pipe(
       ofType(BoardPageActions.goToNode),
+      concatLatestFrom(() => [
+        this.#store.select(boardPageFeature.selectPopupPinned),
+      ]),
+      filter(([, popupPinned]) => !popupPinned),
       map(() => {
         return BoardPageActions.setPopupOpen({
           popup: '',

--- a/apps/web/src/assets/svgs/top-voted.svg
+++ b/apps/web/src/assets/svgs/top-voted.svg
@@ -1,0 +1,9 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 24 24">
+  <path d="M4 19h16v2H4z" />
+  <path d="M6 10h3v7H6z" />
+  <path d="M11 4h3v13h-3z" />
+  <path d="M16 7h3v10h-3z" />
+  <path d="m12.5 1.5.9 1.8 2 .3-1.5 1.4.4 2-1.8-.9-1.8.9.4-2-1.5-1.4 2-.3z" />
+</svg>


### PR DESCRIPTION
## Summary

Adds a fast `Top voted` board toolbar popup for retros so facilitators can jump directly to the most-voted topics instead of scanning the canvas.

## Changes

- Adds a `Top voted` toolbar entry and popup.
- Ranks voted notes and groups by total vote count.
- Adds panel aggregate entries based on voted notes/groups contained inside panels.
- Navigates to a selected result with the existing `goToNode` board navigation.
- Keeps pinned popups open when navigating to a node.
- Keeps the toolbar/sidebar fixed while taller popups scroll independently.

## Root Cause / UX

Retro facilitation commonly starts with the most-voted items, but the board only exposed vote counts on the canvas. Users had to manually search spatially for those items. Also, `goToNode` closed popups unconditionally, so pin/unpin did not work for navigation-based popups.

## Validation

- Commit hooks ran non-API tests and full lint successfully.
- Relevant focused checks run during implementation:
  - `pnpm exec nx test web -- --run src/app/modules/board/components/top-voted/top-voted.utils.spec.ts`
  - `pnpm exec nx test web -- --run src/app/modules/board/effects/board-page.effects.spec.ts`
  - `pnpm exec nx typecheck web`
  - `pnpm exec nx lint web`

Notes: the repo currently warns that Node `^24.13.0` is expected while this environment uses `v22.22.0`; existing lint warnings remain in `apps/web/src/app/modules/board/services/nodes.store.spec.ts`.