### PR TITLE
[codex] Add user note defaults settings

### DIFF
--- a/apps/api/src/app/db/user-db.ts
+++ b/apps/api/src/app/db/user-db.ts
@@ -1,7 +1,12 @@
 import { eq, and, or, desc, sql } from 'drizzle-orm';
 import { db } from './init-db.js';
 import * as schema from '../schema.js';
-import { Invitation, Role, UserInvitation } from '@tapiz/board-commons';
+import {
+  Invitation,
+  Role,
+  UserInvitation,
+  UserSettings,
+} from '@tapiz/board-commons';
 
 export async function getUser(id: string) {
   const users = await db
@@ -41,6 +46,19 @@ export async function getUserByEmail(email: string) {
 
 export async function deleteAccount(userId: string): Promise<unknown> {
   return db.delete(schema.accounts).where(eq(schema.accounts.id, userId));
+}
+
+export async function updateUserSettings(
+  userId: string,
+  settings: UserSettings,
+) {
+  const users = await db
+    .update(schema.accounts)
+    .set({ settings })
+    .where(eq(schema.accounts.id, userId))
+    .returning({ settings: schema.accounts.settings });
+
+  return users.at(0)?.settings;
 }
 
 export async function createUser(

--- a/apps/api/src/app/routers/user-routes.ts
+++ b/apps/api/src/app/routers/user-routes.ts
@@ -4,6 +4,8 @@ import { protectedProcedure, publicProcedure, router } from '../trpc.js';
 import db from '../db/index.js';
 import { getUserInvitationsByEmail } from '../db/user-db.js';
 import { lucia } from '../auth.js';
+import { userSettingsValidator } from '@tapiz/board-commons/validators/user-settings.validator.js';
+import { withDefaultUserSettings } from '@tapiz/board-commons';
 
 export const userRouter = router({
   removeAccount: protectedProcedure.mutation(async (req) => {
@@ -69,12 +71,31 @@ export const userRouter = router({
     };
   }),
   user: protectedProcedure.query(async (req) => {
+    const user = await db.user.getUser(req.ctx.user.sub);
+
     return {
       name: req.ctx.user.name,
       id: req.ctx.user.sub,
       picture: req.ctx.user.picture ?? '',
+      settings: withDefaultUserSettings(user?.settings),
     };
   }),
+  settings: protectedProcedure.query(async (req) => {
+    const user = await db.user.getUser(req.ctx.user.sub);
+
+    return withDefaultUserSettings(user?.settings);
+  }),
+  updateSettings: protectedProcedure
+    .input(userSettingsValidator)
+    .mutation(async (req) => {
+      const settings = withDefaultUserSettings(req.input);
+      const savedSettings = await db.user.updateUserSettings(
+        req.ctx.user.sub,
+        settings,
+      );
+
+      return withDefaultUserSettings(savedSettings);
+    }),
   invites: protectedProcedure.query(async (req) => {
     const email = req.ctx.user.email;
 

--- a/apps/api/src/app/schema.ts
+++ b/apps/api/src/app/schema.ts
@@ -9,8 +9,8 @@ import {
   unique,
   pgEnum,
 } from 'drizzle-orm/pg-core';
-import { relations } from 'drizzle-orm';
-import { TuNode } from '@tapiz/board-commons';
+import { relations, sql } from 'drizzle-orm';
+import { TuNode, UserSettings } from '@tapiz/board-commons';
 
 export const roleEnum = pgEnum('role', ['admin', 'member']);
 export const roleEnumWithGuest = pgEnum('role', ['admin', 'member', 'guest']);
@@ -21,6 +21,12 @@ export const accounts = pgTable('accounts', {
   email: varchar('email', { length: 320 }).notNull().unique(),
   picture: varchar('picture'),
   googleId: varchar('google_id').unique(),
+  settings: json('settings')
+    .$type<UserSettings>()
+    .notNull()
+    .default(
+      sql`'{"noteDefaults":{"backgroundColor":"#fbb980","textColor":"#000000","fontFamily":"\"Inter\", -apple-system, system-ui, sans-serif","bold":false,"italic":false}}'::json`,
+    ),
 });
 
 export const accountsToSession = pgTable('account_session', {

--- a/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.ts
+++ b/apps/web/src/app/modules/board/components/board-toolbar/board-toolbar.component.ts
@@ -5,6 +5,7 @@ import {
   inject,
   signal,
   computed,
+  effect,
 } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { BoardActions } from '../../actions/board.actions';
@@ -29,6 +30,7 @@ import {
   PollBoard,
   Text,
   Timer,
+  defaultUserSettings,
 } from '@tapiz/board-commons';
 import { DrawingStore } from '../drawing/drawing.store';
 import { TemplateSelectorComponent } from '../template-selector/template-selector.component';
@@ -44,13 +46,13 @@ import { LiveReactionComponent } from '../live-reaction/live-reaction.component'
 import { NotesComponent } from '../notes/notes.component';
 import { isInputField } from '@tapiz/cdk/utils/is-input-field';
 import { ToolsComponent } from '../tools/tools.component';
-import { defaultNoteColor } from '../note';
 import { NgTemplateOutlet } from '@angular/common';
 import { BoardToolbardButtonComponent } from './components/board-toolboard-button.component';
 import { LucideAngularModule, Pin, PinOff } from 'lucide-angular';
 import { ArrowToolbarComponent } from '../arrows/arrow-toolbar/arrow-toolbar.component';
 import { PingStore } from '../ping/ping.store';
 import { TopVotedComponent } from '../top-voted/top-voted.component';
+import { appFeature } from '../../../../+state/app.reducer';
 
 export class AppModule {}
 @Component({
@@ -95,9 +97,11 @@ export class BoardToolbarComponent {
 
   toolbarSubscription?: Subscription;
   boardMode = this.#store.selectSignal(boardPageFeature.selectBoardMode);
+  user = this.#store.selectSignal(appFeature.selectUser);
   popup = this.#store.selectSignal(boardPageFeature.selectPopupOpen);
   pinned = this.#store.selectSignal(boardPageFeature.selectPopupPinned);
-  noteColor = signal<string>(defaultNoteColor);
+  noteColor = signal<string>('');
+  #noteColorInitialized = false;
   showPopup = computed(() => {
     const withPopup = [
       'token',
@@ -130,6 +134,17 @@ export class BoardToolbarComponent {
   });
 
   constructor() {
+    effect(() => {
+      const preferredColor =
+        this.user()?.settings.noteDefaults.backgroundColor ??
+        defaultUserSettings.noteDefaults.backgroundColor;
+
+      if (!this.#noteColorInitialized) {
+        this.noteColor.set(preferredColor);
+        this.#noteColorInitialized = true;
+      }
+    });
+
     // Select area (Alt key down)
     fromEvent<KeyboardEvent>(document, 'keydown')
       .pipe(

--- a/apps/web/src/app/modules/board/components/note/note.component.html
+++ b/apps/web/src/app/modules/board/components/note/note.component.html
@@ -31,6 +31,9 @@
         <tapiz-editor-view
           [class.readonly]="!edit()"
           [defaultTextColor]="defaultTextColor()"
+          [defaultFontFamily]="defaultFontFamily()"
+          [defaultBold]="defaultBold()"
+          [defaultItalic]="defaultItalic()"
           #editorView="editorView"
           [content]="initialText()"
           [focus]="edit()"

--- a/apps/web/src/app/modules/board/components/note/note.component.ts
+++ b/apps/web/src/app/modules/board/components/note/note.component.ts
@@ -12,7 +12,15 @@ import {
   afterNextRender,
 } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Drawing, Note, Panel, TuNode, isPanel } from '@tapiz/board-commons';
+import {
+  Drawing,
+  Note,
+  Panel,
+  TuNode,
+  defaultNoteFontFamily,
+  defaultUserSettings,
+  isPanel,
+} from '@tapiz/board-commons';
 import { contrast, lighter } from '@tapiz/cdk/utils/colors';
 import { insideNode } from '@tapiz/cdk/utils/inside-node';
 import { PortalComponent } from '@tapiz/ui/portal';
@@ -39,6 +47,7 @@ import { BoardFacade } from '../../../../services/board-facade.service';
 import { boardPageFeature } from '../../reducers/boardPage.reducer';
 import { BoardPageActions } from '../../actions/board-page.actions';
 import { NodeToolbarComponent } from '../node-toolbar/node-toolbar.component';
+import { appFeature } from '../../../../+state/app.reducer';
 
 @Component({
   selector: 'tapiz-note',
@@ -83,6 +92,7 @@ export class NoteComponent {
   #hotkeysService = inject(HotkeysService);
   #boardFacade = inject(BoardFacade);
   #zoom = this.#store.selectSignal(boardPageFeature.selectZoom);
+  #appUser = this.#store.selectSignal(appFeature.selectUser);
   dropAnimation = signal(false);
   dragAnimation = signal(false);
   noteHeightCalculatorService = inject(NoteHeightCalculatorService);
@@ -142,7 +152,36 @@ export class NoteComponent {
       return null;
     }
 
-    return this.contrast() > 2 ? '#ffffff' : '#000000';
+    return (
+      this.#appUser()?.settings.noteDefaults.textColor ??
+      (this.contrast() > 2 ? '#ffffff' : '#000000')
+    );
+  });
+
+  defaultBold = computed(() => {
+    return (
+      !this.node().content.text.length &&
+      (this.#appUser()?.settings.noteDefaults.bold ??
+        defaultUserSettings.noteDefaults.bold)
+    );
+  });
+
+  defaultItalic = computed(() => {
+    return (
+      !this.node().content.text.length &&
+      (this.#appUser()?.settings.noteDefaults.italic ??
+        defaultUserSettings.noteDefaults.italic)
+    );
+  });
+
+  defaultFontFamily = computed(() => {
+    if (this.node().content.text.length) {
+      return null;
+    }
+
+    return (
+      this.#appUser()?.settings.noteDefaults.fontFamily ?? defaultNoteFontFamily
+    );
   });
 
   generateRandomRotation() {

--- a/apps/web/src/app/modules/board/components/notes/notes.component.ts
+++ b/apps/web/src/app/modules/board/components/notes/notes.component.ts
@@ -7,7 +7,10 @@ import {
 } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { lighter } from '@tapiz/cdk/utils/colors';
-import { ColorPickerComponent } from '@tapiz/ui/color-picker';
+import {
+  ColorPickerComponent,
+  colorPickerSwatches,
+} from '@tapiz/ui/color-picker';
 import { defaultNoteColor } from '../note';
 
 @Component({
@@ -60,27 +63,10 @@ export class NotesComponent {
   customColor = signal<string>(localStorage.getItem('customColor') ?? '');
   colorPickerComponent = viewChild<ColorPickerComponent>('picker');
 
-  notes = [
-    { color: '#a6caf4' },
-    { color: '#88e7e3' },
-    { color: '#92d1b2' },
-    { color: '#badea7' },
-    { color: '#a8d672' },
-    { color: '#cfd45f' },
-    { color: '#f7d44c' },
-    { color: '#f4dd8c' },
-    { color: '#fedeb2' },
-    { color: '#fbb980' },
-    { color: '#ffa4ac' },
-    { color: '#ffb8bf' },
-    { color: '#d6b4ea' },
-    { color: '#ecc5f0' },
-    { color: '#b5b5b5' },
-    { color: '#000000' },
-  ].map((note) => {
+  notes = colorPickerSwatches.map((color) => {
     return {
-      ...note,
-      lightColor: lighter(note.color, 70),
+      color,
+      lightColor: lighter(color, 70),
     };
   });
 

--- a/apps/web/src/app/modules/board/services/notes.service.ts
+++ b/apps/web/src/app/modules/board/services/notes.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { Note, Point, User } from '@tapiz/board-commons';
+import { Note, Point, User, defaultUserSettings } from '@tapiz/board-commons';
 import { BoardActions } from '../actions/board.actions';
 import { BoardFacade } from '../../../services/board-facade.service';
 import { NodesActions } from '../services/nodes-actions';
 import { boardPageFeature } from '../reducers/boardPage.reducer';
+import { appFeature } from '../../../+state/app.reducer';
 
 @Injectable({
   providedIn: 'root',
@@ -12,6 +13,7 @@ import { boardPageFeature } from '../reducers/boardPage.reducer';
 export class NotesService {
   #store = inject(Store);
   #boardMode = this.#store.selectSignal(boardPageFeature.selectBoardMode);
+  #user = this.#store.selectSignal(appFeature.selectUser);
   #boardFacade = inject(BoardFacade);
   #settings = this.#boardFacade.settings;
   #nodesActions = inject(NodesActions);
@@ -40,6 +42,8 @@ export class NotesService {
     }
 
     const anonymousMode = this.#settings()?.content.anonymousMode ?? false;
+    const noteDefaults =
+      this.#user()?.settings.noteDefaults ?? defaultUserSettings.noteDefaults;
 
     const note = this.getNew({
       ownerId: anonymousMode ? '' : userId,
@@ -47,9 +51,7 @@ export class NotesService {
       position,
     });
 
-    if (this.#lastColor) {
-      note.color = this.#lastColor;
-    }
+    note.color = this.#lastColor || noteDefaults.backgroundColor;
 
     const action = this.#nodesActions.add<Note>('note', note);
 

--- a/apps/web/src/app/modules/home/components/settings/settings.component.scss
+++ b/apps/web/src/app/modules/home/components/settings/settings.component.scss
@@ -1,0 +1,128 @@
+:host {
+  display: block;
+  min-block-size: 100%;
+  background: var(--grey-10);
+}
+
+.settings-page {
+  max-inline-size: 960px;
+  margin: 0 auto;
+  padding: var(--spacing-8);
+}
+
+header {
+  margin-block-end: var(--spacing-6);
+
+  h1 {
+    font-size: 2rem;
+    margin: 0;
+  }
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+section {
+  background: var(--white);
+  border: 1px solid var(--grey-30);
+  border-radius: 8px;
+  padding: var(--spacing-6);
+}
+
+.section-header {
+  margin-block-end: var(--spacing-6);
+
+  h2 {
+    font-size: var(--font-size-20);
+    margin: 0;
+  }
+}
+
+.settings-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) 300px;
+  gap: var(--spacing-8);
+  align-items: start;
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-5);
+
+  label {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    gap: var(--spacing-4);
+    font-size: var(--font-size-14);
+  }
+}
+
+.reset {
+  align-self: flex-start;
+  margin-block-start: var(--spacing-2);
+}
+
+.note-preview {
+  aspect-ratio: 1;
+  border: 2px solid rgba(0, 0, 0, 0.08);
+  border-radius: 20px;
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: var(--spacing-5);
+
+  p {
+    font-size: 2rem;
+    line-height: 1.1;
+    margin: 0;
+  }
+
+  span {
+    align-self: flex-start;
+    font-family:
+      "Inter",
+      -apple-system,
+      system-ui,
+      sans-serif;
+    font-size: var(--font-size-14);
+    font-style: normal;
+    font-weight: 500;
+    max-inline-size: 100%;
+    opacity: 0.7;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+}
+
+.actions {
+  align-items: center;
+  display: flex;
+  gap: var(--spacing-3);
+  justify-content: flex-end;
+}
+
+.saved {
+  color: var(--brand);
+  font-size: var(--font-size-14);
+}
+
+@media (max-width: 760px) {
+  .settings-page {
+    padding: var(--spacing-4);
+  }
+
+  .settings-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .note-preview {
+    max-inline-size: 300px;
+  }
+}

--- a/apps/web/src/app/modules/home/components/settings/settings.component.ts
+++ b/apps/web/src/app/modules/home/components/settings/settings.component.ts
@@ -1,0 +1,230 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { ReactiveFormsModule, FormControl, FormGroup } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import {
+  AuthUserModel,
+  NoteFontFamily,
+  UserSettings,
+  defaultUserSettings,
+  noteFontFamilyOptions,
+  withDefaultUserSettings,
+} from '@tapiz/board-commons';
+import { ColorPickerComponent } from '@tapiz/ui/color-picker';
+import { Store } from '@ngrx/store';
+import { appFeature } from '../../../../+state/app.reducer';
+import { UserApiService } from '../../../../services/user-api.service';
+import { AppActions } from '../../../../+state/app.actions';
+import { AuthService } from '../../../../services/auth.service';
+
+@Component({
+  selector: 'tapiz-settings',
+  template: `
+    <div class="settings-page">
+      <header>
+        <h1>Settings</h1>
+      </header>
+
+      <form
+        [formGroup]="form"
+        (ngSubmit)="save()">
+        <section>
+          <div class="section-header">
+            <h2>New notes</h2>
+          </div>
+
+          <div class="settings-grid">
+            <div
+              class="fields"
+              formGroupName="noteDefaults">
+              <label>
+                <span>Background</span>
+                <tapiz-color-picker
+                  [color]="
+                    form.controls.noteDefaults.controls.backgroundColor.value
+                  "
+                  (changed)="updateBackgroundColor($event)" />
+              </label>
+
+              <label>
+                <span>Text color</span>
+                <tapiz-color-picker
+                  [color]="form.controls.noteDefaults.controls.textColor.value"
+                  (changed)="updateTextColor($event)" />
+              </label>
+
+              <mat-form-field>
+                <mat-label>Font</mat-label>
+                <mat-select formControlName="fontFamily">
+                  @for (option of fontFamilyOptions; track option.value) {
+                    <mat-option [value]="option.value">
+                      {{ option.name }}
+                    </mat-option>
+                  }
+                </mat-select>
+              </mat-form-field>
+
+              <mat-checkbox formControlName="bold">Bold</mat-checkbox>
+              <mat-checkbox formControlName="italic">Italic</mat-checkbox>
+
+              <button
+                mat-stroked-button
+                type="button"
+                class="reset"
+                (click)="resetNoteDefaults()">
+                <mat-icon>restart_alt</mat-icon>
+                Reset note
+              </button>
+            </div>
+
+            <div
+              class="note-preview"
+              [style.background]="
+                form.controls.noteDefaults.controls.backgroundColor.value
+              "
+              [style.color]="
+                form.controls.noteDefaults.controls.textColor.value
+              "
+              [style.font-weight]="
+                form.controls.noteDefaults.controls.bold.value ? 700 : 400
+              "
+              [style.font-style]="
+                form.controls.noteDefaults.controls.italic.value
+                  ? 'italic'
+                  : 'normal'
+              ">
+              <p
+                [style.font-family]="
+                  form.controls.noteDefaults.controls.fontFamily.value
+                ">
+                Write the next step
+              </p>
+              <span>{{ user()?.name }}</span>
+            </div>
+          </div>
+        </section>
+
+        <div class="actions">
+          @if (saved()) {
+            <span class="saved">Saved</span>
+          }
+
+          <button
+            mat-flat-button
+            color="primary"
+            type="submit">
+            <mat-icon>save</mat-icon>
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  `,
+  styleUrl: './settings.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    ReactiveFormsModule,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatSelectModule,
+    ColorPickerComponent,
+  ],
+})
+export class SettingsComponent {
+  #store = inject(Store);
+  #userApiService = inject(UserApiService);
+  #authService = inject(AuthService);
+
+  user = this.#store.selectSignal(appFeature.selectUser);
+  saved = signal(false);
+  fontFamilyOptions = noteFontFamilyOptions;
+  #formInitialized = false;
+
+  form = new FormGroup({
+    noteDefaults: new FormGroup({
+      backgroundColor: new FormControl(
+        defaultUserSettings.noteDefaults.backgroundColor,
+        { nonNullable: true },
+      ),
+      textColor: new FormControl(defaultUserSettings.noteDefaults.textColor, {
+        nonNullable: true,
+      }),
+      fontFamily: new FormControl<NoteFontFamily>(
+        defaultUserSettings.noteDefaults.fontFamily,
+        {
+          nonNullable: true,
+        },
+      ),
+      bold: new FormControl(defaultUserSettings.noteDefaults.bold, {
+        nonNullable: true,
+      }),
+      italic: new FormControl(defaultUserSettings.noteDefaults.italic, {
+        nonNullable: true,
+      }),
+    }),
+  });
+
+  constructor() {
+    effect(() => {
+      const user = this.user();
+
+      if (!user || this.#formInitialized) {
+        return;
+      }
+
+      const settings = withDefaultUserSettings(user.settings);
+
+      this.form.setValue(settings);
+      this.#formInitialized = true;
+    });
+  }
+
+  updateBackgroundColor(color: string | undefined) {
+    this.form.controls.noteDefaults.controls.backgroundColor.setValue(
+      color ?? defaultUserSettings.noteDefaults.backgroundColor,
+    );
+  }
+
+  updateTextColor(color: string | undefined) {
+    this.form.controls.noteDefaults.controls.textColor.setValue(
+      color ?? defaultUserSettings.noteDefaults.textColor,
+    );
+  }
+
+  resetNoteDefaults() {
+    this.form.controls.noteDefaults.setValue(defaultUserSettings.noteDefaults);
+    this.saved.set(false);
+  }
+
+  save() {
+    const settings: UserSettings = this.form.getRawValue();
+
+    this.#userApiService.updateSettings(settings).subscribe((savedSettings) => {
+      const currentUser = this.user();
+
+      if (!currentUser) {
+        return;
+      }
+
+      const user: AuthUserModel = {
+        ...currentUser,
+        settings: savedSettings,
+      };
+
+      this.#store.dispatch(AppActions.setUser({ user }));
+      this.#authService.setLocalStoreUser(user);
+      this.saved.set(true);
+    });
+  }
+}

--- a/apps/web/src/app/modules/home/home.component.ts
+++ b/apps/web/src/app/modules/home/home.component.ts
@@ -83,6 +83,12 @@ import { injectQueryParams } from 'ngxtension/inject-query-params';
         <mat-menu #menu="matMenu">
           <button
             mat-menu-item
+            routerLink="/settings">
+            <mat-icon>settings</mat-icon>
+            <span>Settings</span>
+          </button>
+          <button
+            mat-menu-item
             (click)="deleteAccount()">
             <mat-icon>person_remove</mat-icon>
             <span>Delete account</span>

--- a/apps/web/src/app/modules/home/home.routes.ts
+++ b/apps/web/src/app/modules/home/home.routes.ts
@@ -7,6 +7,7 @@ import { homeFeature } from './+state/home.feature';
 import { AllBoardsComponent } from './components/all-boards/all-boards.component';
 import { TeamComponent } from './components/team/team.component';
 import { StarredComponent } from './components/starred/starred.component';
+import { SettingsComponent } from './components/settings/settings.component';
 
 export const homesRoutes: Route[] = [
   {
@@ -21,6 +22,10 @@ export const homesRoutes: Route[] = [
       {
         path: 'starred',
         component: StarredComponent,
+      },
+      {
+        path: 'settings',
+        component: SettingsComponent,
       },
       {
         path: '',

--- a/apps/web/src/app/services/auth.service.ts
+++ b/apps/web/src/app/services/auth.service.ts
@@ -4,7 +4,7 @@ import { BehaviorSubject, take } from 'rxjs';
 import { AppActions } from '../+state/app.actions';
 import { filterNil } from 'ngxtension/filter-nil';
 import { appFeature } from '../+state/app.reducer';
-import { AuthUserModel } from '@tapiz/board-commons';
+import { AuthUserModel, withDefaultUserSettings } from '@tapiz/board-commons';
 
 @Injectable({
   providedIn: 'root',
@@ -17,7 +17,13 @@ export class AuthService {
     const user = localStorage.getItem('user');
 
     if (user) {
-      this.store.dispatch(AppActions.setUser({ user: JSON.parse(user) }));
+      const parsedUser = JSON.parse(user) as AuthUserModel;
+      const normalizedUser = {
+        ...parsedUser,
+        settings: withDefaultUserSettings(parsedUser.settings),
+      };
+
+      this.store.dispatch(AppActions.setUser({ user: normalizedUser }));
 
       this.store
         .select(appFeature.selectUser)

--- a/apps/web/src/app/services/user-api.service.ts
+++ b/apps/web/src/app/services/user-api.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { from } from 'rxjs';
 import { APIConfigService } from './api-config.service';
+import { UserSettings } from '@tapiz/board-commons';
 
 @Injectable({
   providedIn: 'root',
@@ -29,6 +30,14 @@ export class UserApiService {
 
   user() {
     return from(this.trpc.user.user.query());
+  }
+
+  settings() {
+    return from(this.trpc.user.settings.query());
+  }
+
+  updateSettings(settings: UserSettings) {
+    return from(this.trpc.user.updateSettings.mutate(settings));
   }
 
   notifications(offset = 0) {

--- a/apps/web/src/app/styles/override-material.scss
+++ b/apps/web/src/app/styles/override-material.scss
@@ -57,11 +57,17 @@ button.mdc-button {
   --mdc-snackbar-container-color: var(--error);
 }
 
-.mat-mdc-checkbox.mat-primary {
+.mat-mdc-checkbox {
   --mat-checkbox-selected-icon-color: var(--brand);
-  --mdc-checkbox-selected-focus-icon-color: var(--brand);
-  --mdc-checkbox-selected-focus-state-layer-color: var(--grey-70);
   --mat-checkbox-selected-focus-icon-color: var(--brand);
+  --mat-checkbox-selected-hover-icon-color: var(--brand);
+  --mat-checkbox-selected-checkmark-color: var(--white);
+  --mat-checkbox-selected-focus-state-layer-color: var(--brand);
+  --mat-checkbox-selected-hover-state-layer-color: var(--brand);
+  --mat-checkbox-selected-pressed-state-layer-color: var(--brand);
+  --mat-checkbox-unselected-focus-state-layer-color: var(--grey-70);
+  --mat-checkbox-unselected-hover-state-layer-color: var(--grey-70);
+  --mat-checkbox-unselected-pressed-state-layer-color: var(--grey-70);
 }
 
 :root {

--- a/drizzle/0008_first_naoko.sql
+++ b/drizzle/0008_first_naoko.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "spaces" ALTER COLUMN "team_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "settings" json DEFAULT '{"noteDefaults":{"backgroundColor":"#fbb980","textColor":"#000000","fontFamily":"\"Inter\", -apple-system, system-ui, sans-serif","bold":false,"italic":false}}'::json NOT NULL;

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,698 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "77e11128-b858-4b21-b5e4-5bbc1465e657",
+  "prevId": "cd9ff63b-fbb7-477a-ad1b-95c2d28f3fbd",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"noteDefaults\":{\"backgroundColor\":\"#fbb980\",\"textColor\":\"#000000\",\"fontFamily\":\"\\\"Inter\\\", -apple-system, system-ui, sans-serif\",\"bold\":false,\"italic\":false}}'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_email_unique": {
+          "name": "accounts_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "accounts_google_id_unique": {
+          "name": "accounts_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["google_id"]
+        }
+      }
+    },
+    "account_session": {
+      "name": "account_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_session_user_id_accounts_id_fk": {
+          "name": "account_session_user_id_accounts_id_fk",
+          "tableFrom": "account_session",
+          "tableTo": "accounts",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "accounts_boards": {
+      "name": "accounts_boards",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_id": {
+          "name": "private_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_boards_account_id_accounts_id_fk": {
+          "name": "accounts_boards_account_id_accounts_id_fk",
+          "tableFrom": "accounts_boards",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_boards_board_id_boards_id_fk": {
+          "name": "accounts_boards_board_id_boards_id_fk",
+          "tableFrom": "accounts_boards",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_boards_account_id_board_id": {
+          "name": "accounts_boards_account_id_board_id",
+          "columns": ["account_id", "board_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "board_files": {
+      "name": "board_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_files_board_id_boards_id_fk": {
+          "name": "board_files_board_id_boards_id_fk",
+          "tableFrom": "board_files",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board": {
+          "name": "board",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_team_id_teams_id_fk": {
+          "name": "boards_team_id_teams_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_user_id_accounts_id_fk": {
+          "name": "invitations_user_id_accounts_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_board_id_boards_id_fk": {
+          "name": "invitations_board_id_boards_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_accounts_id_fk": {
+          "name": "invitations_inviter_id_accounts_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_team_id_user_id_unique": {
+          "name": "invitations_team_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id", "user_id"]
+        },
+        "invitations_board_id_user_id_unique": {
+          "name": "invitations_board_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["board_id", "user_id"]
+        },
+        "invitations_team_id_email_unique": {
+          "name": "invitations_team_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id", "email"]
+        },
+        "invitations_board_id_email_unique": {
+          "name": "invitations_board_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["board_id", "email"]
+        }
+      }
+    },
+    "notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_board_id_boards_id_fk": {
+          "name": "notifications_board_id_boards_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_accounts_id_fk": {
+          "name": "notifications_user_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "space_boards": {
+      "name": "space_boards",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_boards_space_id_spaces_id_fk": {
+          "name": "space_boards_space_id_spaces_id_fk",
+          "tableFrom": "space_boards",
+          "tableTo": "spaces",
+          "columnsFrom": ["space_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "space_boards_board_id_boards_id_fk": {
+          "name": "space_boards_board_id_boards_id_fk",
+          "tableFrom": "space_boards",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "space_boards_space_id_board_id": {
+          "name": "space_boards_space_id_board_id",
+          "columns": ["space_id", "board_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spaces_team_id_teams_id_fk": {
+          "name": "spaces_team_id_teams_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "starreds": {
+      "name": "starreds",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "starreds_account_id_accounts_id_fk": {
+          "name": "starreds_account_id_accounts_id_fk",
+          "tableFrom": "starreds",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "starreds_board_id_boards_id_fk": {
+          "name": "starreds_board_id_boards_id_fk",
+          "tableFrom": "starreds",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "starreds_account_id_board_id": {
+          "name": "starreds_account_id_board_id",
+          "columns": ["account_id", "board_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_account_id_accounts_id_fk": {
+          "name": "team_members_account_id_accounts_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_team_id_account_id": {
+          "name": "team_members_team_id_account_id",
+          "columns": ["team_id", "account_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "role": {
+      "name": "role",
+      "values": {
+        "admin": "admin",
+        "member": "member",
+        "guest": "guest"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1731514196823,
       "tag": "0007_fixed_korath",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "5",
+      "when": 1782121596868,
+      "tag": "0008_first_naoko",
+      "breakpoints": true
     }
   ]
 }

--- a/libs/board-commons/src/lib/models/auth-user.model.ts
+++ b/libs/board-commons/src/lib/models/auth-user.model.ts
@@ -1,5 +1,76 @@
+export const noteFontFamilyValues = [
+  '"Inter", -apple-system, system-ui, sans-serif',
+  'system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;',
+  'ui-serif, serif',
+  'Dank Mono, Operator Mono, Inconsolata, Fira Mono, ui-monospace, SF Mono, Monaco, Droid Sans Mono, Source Code Pro, Cascadia Code, Menlo, Consolas, DejaVu Sans Mono, monospace',
+  'Caveat, cursive',
+] as const;
+
+export const noteFontFamilyOptions = [
+  {
+    name: 'Default',
+    value: noteFontFamilyValues[0],
+  },
+  {
+    name: 'Sans',
+    value: noteFontFamilyValues[1],
+  },
+  {
+    name: 'Serif',
+    value: noteFontFamilyValues[2],
+  },
+  {
+    name: 'Mono',
+    value: noteFontFamilyValues[3],
+  },
+  {
+    name: 'Handwriting',
+    value: noteFontFamilyValues[4],
+  },
+] as const;
+
+export const defaultNoteFontFamily = noteFontFamilyValues[0];
+
+export type NoteFontFamily = (typeof noteFontFamilyValues)[number];
+
+export interface UserNoteDefaults {
+  backgroundColor: string;
+  textColor: string;
+  fontFamily: NoteFontFamily;
+  bold: boolean;
+  italic: boolean;
+}
+
+export interface UserSettings {
+  noteDefaults: UserNoteDefaults;
+}
+
+export const defaultUserSettings: UserSettings = {
+  noteDefaults: {
+    backgroundColor: '#fbb980',
+    textColor: '#000000',
+    fontFamily: defaultNoteFontFamily,
+    bold: false,
+    italic: false,
+  },
+};
+
+export function withDefaultUserSettings(
+  settings?: Partial<UserSettings> | null,
+): UserSettings {
+  return {
+    ...defaultUserSettings,
+    ...settings,
+    noteDefaults: {
+      ...defaultUserSettings.noteDefaults,
+      ...settings?.noteDefaults,
+    },
+  };
+}
+
 export interface AuthUserModel {
   name: string;
   picture: string;
   id: string;
+  settings: UserSettings;
 }

--- a/libs/board-commons/src/lib/validators/user-settings.validator.ts
+++ b/libs/board-commons/src/lib/validators/user-settings.validator.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod/v4';
+import {
+  defaultUserSettings,
+  noteFontFamilyValues,
+} from '../models/auth-user.model.js';
+import { colorSchema } from './color.validator.js';
+
+export const userSettingsValidator = z.object({
+  noteDefaults: z.object({
+    backgroundColor: colorSchema.default(
+      defaultUserSettings.noteDefaults.backgroundColor,
+    ),
+    textColor: colorSchema.default(defaultUserSettings.noteDefaults.textColor),
+    fontFamily: z
+      .enum(noteFontFamilyValues)
+      .default(defaultUserSettings.noteDefaults.fontFamily),
+    bold: z.boolean().default(defaultUserSettings.noteDefaults.bold),
+    italic: z.boolean().default(defaultUserSettings.noteDefaults.italic),
+  }),
+});

--- a/libs/ui/src/lib/color-picker/color-picker.config.ts
+++ b/libs/ui/src/lib/color-picker/color-picker.config.ts
@@ -1,24 +1,28 @@
 import type Pickr from '@simonwep/pickr';
 
+export const colorPickerSwatches = [
+  '#a6caf4',
+  '#88e7e3',
+  '#92d1b2',
+  '#badea7',
+  '#a8d672',
+  '#cfd45f',
+  '#f7d44c',
+  '#f4dd8c',
+  '#fedeb2',
+  '#fbb980',
+  '#ffa4ac',
+  '#ffb8bf',
+  '#d6b4ea',
+  '#ecc5f0',
+  '#b5b5b5',
+  '#000000',
+];
+
 export const colorPickerConfig: Partial<Pickr.Options> = {
   theme: 'monolith',
   default: '',
-  swatches: [
-    'rgba(244, 67, 54, 1)',
-    'rgba(233, 30, 99, 1)',
-    'rgba(156, 39, 176, 1)',
-    'rgba(103, 58, 183, 1)',
-    'rgba(63, 81, 181, 1)',
-    'rgba(33, 150, 243, 1)',
-    'rgba(3, 169, 244, 1)',
-    'rgba(0, 188, 212, 1)',
-    'rgba(0, 150, 136, 1)',
-    'rgba(76, 175, 80, 1)',
-    'rgba(139, 195, 74, 1)',
-    'rgba(205, 220, 57, 1)',
-    'rgba(255, 235, 59, 1)',
-    'rgba(255, 193, 7, 1)',
-  ],
+  swatches: colorPickerSwatches,
   components: {
     preview: true,
     opacity: true,

--- a/libs/ui/src/lib/color-picker/index.ts
+++ b/libs/ui/src/lib/color-picker/index.ts
@@ -1,1 +1,2 @@
 export { ColorPickerComponent } from './color-picker.component';
+export { colorPickerSwatches } from './color-picker.config';

--- a/libs/ui/src/lib/editor-view/editor-view.component.ts
+++ b/libs/ui/src/lib/editor-view/editor-view.component.ts
@@ -30,6 +30,7 @@ import { input } from '@angular/core';
 import { PopupComponent } from '../popup/popup.component';
 import { normalize } from '@tapiz/utils/normalize';
 import { explicitEffect } from 'ngxtension/explicit-effect';
+import { defaultNoteFontFamily } from '@tapiz/board-commons';
 
 @Component({
   selector: 'tapiz-editor-view',
@@ -81,6 +82,9 @@ export class EditorViewComponent implements OnDestroy, AfterViewInit {
   focus = input<boolean>(false);
   customClass = input('');
   defaultTextColor = input<string | null>(null);
+  defaultFontFamily = input<string | null>(null);
+  defaultBold = input(false);
+  defaultItalic = input(false);
   popupComponent = viewChild(PopupComponent);
   mentions = input<{ id: string; name: string }[]>([]);
   suggestedMentions = signal<{ id: string; name: string }[]>([]);
@@ -260,10 +264,26 @@ export class EditorViewComponent implements OnDestroy, AfterViewInit {
         }
 
         const defaultTextColor = this.defaultTextColor();
+        const defaultFontFamily = this.defaultFontFamily();
+        const chain = editor.chain();
 
         if (defaultTextColor) {
-          editor.chain().setColor(defaultTextColor).run();
+          chain.setColor(defaultTextColor);
         }
+
+        if (defaultFontFamily && defaultFontFamily !== defaultNoteFontFamily) {
+          chain.setFontFamily(defaultFontFamily);
+        }
+
+        if (this.defaultBold()) {
+          chain.toggleBold();
+        }
+
+        if (this.defaultItalic()) {
+          chain.toggleItalic();
+        }
+
+        chain.run();
       },
     });
 

--- a/libs/ui/src/lib/toolbar/options/font/option-font.component.ts
+++ b/libs/ui/src/lib/toolbar/options/font/option-font.component.ts
@@ -13,6 +13,10 @@ import { ToolbarEditorService } from '../../toolbar-editor.service';
 import { ColorPickerComponent } from '../../../color-picker';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import {
+  defaultNoteFontFamily,
+  noteFontFamilyOptions,
+} from '@tapiz/board-commons';
 
 @Component({
   selector: 'tapiz-toolbar-option-font',
@@ -44,34 +48,11 @@ export class OptionFontComponent {
   editor = input.required<Editor>();
   defaultTextColor = input('#000000');
 
-  options = [
-    {
-      name: 'Default',
-      value: '"Inter", -apple-system, system-ui, sans-serif',
-    },
-    {
-      name: 'Sans',
-      value:
-        'system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;',
-    },
-    {
-      name: 'Serif',
-      value: 'ui-serif, serif',
-    },
-    {
-      name: 'Mono',
-      value:
-        'Dank Mono, Operator Mono, Inconsolata, Fira Mono, ui-monospace, SF Mono, Monaco, Droid Sans Mono, Source Code Pro, Cascadia Code, Menlo, Consolas, DejaVu Sans Mono, monospace',
-    },
-    {
-      name: 'Handwriting',
-      value: 'Caveat, cursive',
-    },
-  ];
+  options = noteFontFamilyOptions;
 
   color = signal<string | null>(null);
 
-  #defaultFontFamily = this.options[0].value;
+  #defaultFontFamily = defaultNoteFontFamily;
   fontFamilyValue = signal<string>(this.#defaultFontFamily);
 
   #toolbarEditorService = inject(ToolbarEditorService);


### PR DESCRIPTION
## What changed

- Added a user Settings screen reachable from the avatar menu.
- Added persisted user note defaults for new notes: background color, text color, font family, bold, and italic.
- Added a preview and reset action for the note defaults form.
- Applied the defaults when creating/editing new empty notes while keeping note text formatting persisted in the existing rich text HTML.
- Reused the note color palette in the shared color picker and aligned Material checkbox tokens with the app theme.
- Added a Drizzle migration for the new `accounts.settings` JSON column.

## Validation

- `pnpm exec nx build api`
- `pnpm exec nx build web --configuration=development`
- Commit hook: `pnpm test`
- Commit hook: `pnpm lint` (passes with existing warnings in `apps/web/src/app/modules/board/services/nodes.store.spec.ts`)

## Notes

Drizzle also included `ALTER TABLE "spaces" ALTER COLUMN "team_id" SET NOT NULL` in the generated migration because the current schema declares that column as required while the previous snapshot did not.