### PR TITLE
[codex] Add user API tokens

### DIFF
--- a/apps/api/src/app/api-token.ts
+++ b/apps/api/src/app/api-token.ts
@@ -1,0 +1,17 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+export const API_TOKEN_PREFIX = 'tapiz_pat_';
+
+export function generateApiToken() {
+  return `${API_TOKEN_PREFIX}${randomBytes(32).toString('base64url')}`;
+}
+
+export function hashApiToken(token: string) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function isApiToken(token: string) {
+  return (
+    token.startsWith(API_TOKEN_PREFIX) && token.length > API_TOKEN_PREFIX.length
+  );
+}

--- a/apps/api/src/app/app.context.ts
+++ b/apps/api/src/app/app.context.ts
@@ -1,8 +1,9 @@
 import { inferAsyncReturnType } from '@trpc/server';
 import { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
-import { getUser } from './db/user-db.js';
+import { getUser, getUserByApiTokenHash } from './db/user-db.js';
 import { lucia, validateSession } from './auth.js';
 import { FastifyInstance } from 'fastify';
+import { hashApiToken, isApiToken } from './api-token.js';
 
 // // prevent angular build errors
 import '@fastify/rate-limit';
@@ -12,7 +13,20 @@ export async function createAuthContext({
   req,
   res,
 }: CreateFastifyContextOptions) {
-  async function getUserFromHeader() {
+  function toAuthUser(dbUser: Awaited<ReturnType<typeof getUser>>) {
+    if (!dbUser) {
+      return null;
+    }
+
+    return {
+      sub: dbUser.id,
+      name: dbUser.name,
+      email: dbUser.email,
+      picture: dbUser.picture,
+    };
+  }
+
+  async function getUserFromSessionCookie() {
     const cookies = req.cookies;
 
     const sessionId = cookies[lucia.sessionCookieName];
@@ -50,22 +64,32 @@ export async function createAuthContext({
 
       const dbUser = await getUser(user.id);
 
-      if (!dbUser) {
-        return null;
-      }
-
-      return {
-        sub: dbUser.id,
-        name: dbUser.name,
-        email: dbUser.email,
-        picture: dbUser.picture,
-      };
+      return toAuthUser(dbUser);
     }
 
     return null;
   }
 
-  const user = await getUserFromHeader();
+  async function getUserFromApiToken() {
+    const authorization = req.headers.authorization;
+
+    if (!authorization?.startsWith('Bearer ')) {
+      return null;
+    }
+
+    const token = authorization.slice('Bearer '.length).trim();
+
+    if (!isApiToken(token)) {
+      return null;
+    }
+
+    const dbUser = await getUserByApiTokenHash(hashApiToken(token));
+
+    return toAuthUser(dbUser);
+  }
+
+  const user =
+    (await getUserFromSessionCookie()) ?? (await getUserFromApiToken());
 
   return {
     user,

--- a/apps/api/src/app/db/init-db.ts
+++ b/apps/api/src/app/db/init-db.ts
@@ -43,7 +43,7 @@ async function dbMigrate() {
 export async function startDB() {
   const run = async () => {
     try {
-      dbMigrate();
+      await dbMigrate();
       initDbClient();
     } catch (e) {
       console.log('Error connecting to DB, retrying in 2 seconds');

--- a/apps/api/src/app/db/user-db.ts
+++ b/apps/api/src/app/db/user-db.ts
@@ -44,6 +44,15 @@ export async function getUserByEmail(email: string) {
   return users.at(0);
 }
 
+export async function getUserByApiTokenHash(apiTokenHash: string) {
+  const users = await db
+    .select()
+    .from(schema.accounts)
+    .where(eq(schema.accounts.apiTokenHash, apiTokenHash));
+
+  return users.at(0);
+}
+
 export async function deleteAccount(userId: string): Promise<unknown> {
   return db.delete(schema.accounts).where(eq(schema.accounts.id, userId));
 }
@@ -59,6 +68,42 @@ export async function updateUserSettings(
     .returning({ settings: schema.accounts.settings });
 
   return users.at(0)?.settings;
+}
+
+export async function getUserApiTokenInfo(userId: string) {
+  const users = await db
+    .select({
+      apiTokenHash: schema.accounts.apiTokenHash,
+      apiTokenCreatedAt: schema.accounts.apiTokenCreatedAt,
+    })
+    .from(schema.accounts)
+    .where(eq(schema.accounts.id, userId));
+
+  const user = users.at(0);
+
+  if (!user) {
+    return null;
+  }
+
+  return {
+    hasToken: !!user.apiTokenHash,
+    createdAt: user.apiTokenCreatedAt,
+  };
+}
+
+export async function updateUserApiToken(userId: string, apiTokenHash: string) {
+  const users = await db
+    .update(schema.accounts)
+    .set({
+      apiTokenHash,
+      apiTokenCreatedAt: sql`now()`,
+    })
+    .where(eq(schema.accounts.id, userId))
+    .returning({
+      apiTokenCreatedAt: schema.accounts.apiTokenCreatedAt,
+    });
+
+  return users.at(0)?.apiTokenCreatedAt;
 }
 
 export async function createUser(

--- a/apps/api/src/app/routers/user-routes.ts
+++ b/apps/api/src/app/routers/user-routes.ts
@@ -6,6 +6,7 @@ import { getUserInvitationsByEmail } from '../db/user-db.js';
 import { lucia } from '../auth.js';
 import { userSettingsValidator } from '@tapiz/board-commons/validators/user-settings.validator.js';
 import { withDefaultUserSettings } from '@tapiz/board-commons';
+import { generateApiToken, hashApiToken } from '../api-token.js';
 
 export const userRouter = router({
   removeAccount: protectedProcedure.mutation(async (req) => {
@@ -96,6 +97,23 @@ export const userRouter = router({
 
       return withDefaultUserSettings(savedSettings);
     }),
+  apiToken: protectedProcedure.query(async (req) => {
+    const tokenInfo = await db.user.getUserApiTokenInfo(req.ctx.user.sub);
+
+    return tokenInfo ?? { hasToken: false, createdAt: null };
+  }),
+  generateApiToken: protectedProcedure.mutation(async (req) => {
+    const token = generateApiToken();
+    const createdAt = await db.user.updateUserApiToken(
+      req.ctx.user.sub,
+      hashApiToken(token),
+    );
+
+    return {
+      token,
+      createdAt,
+    };
+  }),
   invites: protectedProcedure.query(async (req) => {
     const email = req.ctx.user.email;
 

--- a/apps/api/src/app/schema.ts
+++ b/apps/api/src/app/schema.ts
@@ -21,6 +21,8 @@ export const accounts = pgTable('accounts', {
   email: varchar('email', { length: 320 }).notNull().unique(),
   picture: varchar('picture'),
   googleId: varchar('google_id').unique(),
+  apiTokenHash: varchar('api_token_hash', { length: 64 }).unique(),
+  apiTokenCreatedAt: timestamp('api_token_created_at', { mode: 'string' }),
   settings: json('settings')
     .$type<UserSettings>()
     .notNull()

--- a/apps/api/src/tests/api-users.spec.ts
+++ b/apps/api/src/tests/api-users.spec.ts
@@ -1,7 +1,10 @@
 import { lucia } from '../app/auth';
+import { API_TOKEN_PREFIX, hashApiToken } from '../app/api-token';
+import { createAuthContext } from '../app/app.context';
 import db from '../app/db';
 import { startDB } from '../app/db/init-db';
 import { createMultipleUsers, getAuth, getUserCaller } from './test-helpers';
+import { vi } from 'vitest';
 
 describe('user', () => {
   beforeAll(async () => {
@@ -43,6 +46,65 @@ describe('user', () => {
 
     expect(team).toBeFalsy();
     expect(board).toBeFalsy();
+  });
+
+  it('generates and regenerates an api token for bearer auth', async () => {
+    const caller = await getUserCaller(9);
+    const tokenInfo = await caller.user.apiToken();
+
+    expect(tokenInfo.hasToken).toEqual(false);
+
+    const firstToken = await caller.user.generateApiToken();
+
+    expect(firstToken.token.startsWith(API_TOKEN_PREFIX)).toEqual(true);
+
+    const storedUser = await db.user.getUserByApiTokenHash(
+      hashApiToken(firstToken.token),
+    );
+
+    expect(storedUser?.id).toEqual(getAuth(9).sub);
+    expect(storedUser?.apiTokenHash).not.toEqual(firstToken.token);
+
+    const firstContext = await createAuthContext({
+      req: {
+        cookies: {},
+        headers: {
+          authorization: `Bearer ${firstToken.token}`,
+        },
+      },
+      res: {
+        setCookie: vi.fn(),
+      },
+    } as Parameters<typeof createAuthContext>[0]);
+
+    expect(firstContext.user?.sub).toEqual(getAuth(9).sub);
+
+    const secondToken = await caller.user.generateApiToken();
+    const oldTokenContext = await createAuthContext({
+      req: {
+        cookies: {},
+        headers: {
+          authorization: `Bearer ${firstToken.token}`,
+        },
+      },
+      res: {
+        setCookie: vi.fn(),
+      },
+    } as Parameters<typeof createAuthContext>[0]);
+    const newTokenContext = await createAuthContext({
+      req: {
+        cookies: {},
+        headers: {
+          authorization: `Bearer ${secondToken.token}`,
+        },
+      },
+      res: {
+        setCookie: vi.fn(),
+      },
+    } as Parameters<typeof createAuthContext>[0]);
+
+    expect(oldTokenContext.user).toBeNull();
+    expect(newTokenContext.user?.sub).toEqual(getAuth(9).sub);
   });
 
   it('delete account should transfer ownership', async () => {

--- a/apps/web/src/app/modules/home/components/settings/settings.component.scss
+++ b/apps/web/src/app/modules/home/components/settings/settings.component.scss
@@ -113,6 +113,49 @@ section {
   font-size: var(--font-size-14);
 }
 
+.api-token {
+  align-items: start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.api-token-status {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--spacing-2);
+  min-inline-size: 0;
+
+  span {
+    font-size: var(--font-size-14);
+    font-weight: 500;
+  }
+
+  small {
+    color: var(--brand);
+    font-size: var(--font-size-12);
+  }
+
+  code {
+    background: var(--grey-20);
+    border: 1px solid var(--grey-30);
+    border-radius: 6px;
+    font-size: var(--font-size-14);
+    inline-size: 100%;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    padding: var(--spacing-3);
+  }
+}
+
+.api-token-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-2);
+  justify-content: flex-start;
+}
+
 @media (max-width: 760px) {
   .settings-page {
     padding: var(--spacing-4);

--- a/apps/web/src/app/modules/home/components/settings/settings.component.spec.ts
+++ b/apps/web/src/app/modules/home/components/settings/settings.component.spec.ts
@@ -1,0 +1,81 @@
+import { provideZonelessChangeDetection, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Store } from '@ngrx/store';
+import { AuthUserModel, defaultUserSettings } from '@tapiz/board-commons';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthService } from '../../../../services/auth.service';
+import { UserApiService } from '../../../../services/user-api.service';
+import { SettingsComponent } from './settings.component';
+
+describe('SettingsComponent', () => {
+  let apiToken: ReturnType<typeof vi.fn>;
+  let generateApiToken: ReturnType<typeof vi.fn>;
+  let updateSettings: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    const user = signal<AuthUserModel | null>({
+      id: 'user-1',
+      name: 'Ada',
+      picture: '',
+      settings: defaultUserSettings,
+    });
+
+    apiToken = vi.fn(() => of({ hasToken: true, createdAt: '2026-06-25' }));
+    generateApiToken = vi.fn(() =>
+      of({ token: 'tapiz_pat_generated', createdAt: '2026-06-25' }),
+    );
+    updateSettings = vi.fn(() => of(defaultUserSettings));
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideZonelessChangeDetection(),
+        {
+          provide: Store,
+          useValue: {
+            dispatch: vi.fn(),
+            selectSignal: () => user,
+          },
+        },
+        {
+          provide: UserApiService,
+          useValue: {
+            apiToken,
+            generateApiToken,
+            updateSettings,
+          },
+        },
+        {
+          provide: AuthService,
+          useValue: {
+            setLocalStoreUser: vi.fn(),
+          },
+        },
+      ],
+    });
+  });
+
+  it('keeps the api token state after reloading settings', () => {
+    const component = TestBed.runInInjectionContext(
+      () => new SettingsComponent(),
+    );
+
+    expect(apiToken).toHaveBeenCalledOnce();
+    expect(component.apiTokenLoading()).toEqual(false);
+    expect(component.apiTokenExists()).toEqual(true);
+    expect(component.generatedApiToken()).toBeNull();
+  });
+
+  it('shows the newly generated token without waiting for save', () => {
+    const component = TestBed.runInInjectionContext(
+      () => new SettingsComponent(),
+    );
+
+    component.generateApiToken();
+
+    expect(generateApiToken).toHaveBeenCalledOnce();
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(component.apiTokenExists()).toEqual(true);
+    expect(component.generatedApiToken()).toEqual('tapiz_pat_generated');
+  });
+});

--- a/apps/web/src/app/modules/home/components/settings/settings.component.ts
+++ b/apps/web/src/app/modules/home/components/settings/settings.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   effect,
   inject,
   signal,
@@ -113,6 +114,52 @@ import { AuthService } from '../../../../services/auth.service';
           </div>
         </section>
 
+        <section>
+          <div class="section-header">
+            <h2>API token</h2>
+          </div>
+
+          <div class="api-token">
+            <div class="api-token-status">
+              @if (generatedApiToken()) {
+                <span>New token</span>
+                <code>{{ generatedApiToken() }}</code>
+              } @else if (apiTokenLoading()) {
+                <span>Checking token</span>
+              } @else if (apiTokenExists()) {
+                <span>Token generated</span>
+                <small>The token is hidden after reload.</small>
+              } @else {
+                <span>No token</span>
+              }
+
+              @if (tokenCopied()) {
+                <small>Copied</small>
+              }
+            </div>
+
+            <div class="api-token-actions">
+              @if (generatedApiToken()) {
+                <button
+                  mat-stroked-button
+                  type="button"
+                  (click)="copyGeneratedToken()">
+                  <mat-icon>content_copy</mat-icon>
+                  Copy
+                </button>
+              }
+
+              <button
+                mat-stroked-button
+                type="button"
+                (click)="generateApiToken()">
+                <mat-icon>{{ apiTokenExists() ? 'sync' : 'add' }}</mat-icon>
+                {{ apiTokenExists() ? 'Regenerate' : 'Generate token' }}
+              </button>
+            </div>
+          </div>
+        </section>
+
         <div class="actions">
           @if (saved()) {
             <span class="saved">Saved</span>
@@ -148,6 +195,17 @@ export class SettingsComponent {
 
   user = this.#store.selectSignal(appFeature.selectUser);
   saved = signal(false);
+  apiTokenLoading = signal(true);
+  apiTokenInfo = signal<{ hasToken: boolean; createdAt: string | null } | null>(
+    null,
+  );
+  generatedApiToken = signal<string | null>(null);
+  tokenCopied = signal(false);
+  apiTokenExists = computed(() => {
+    return (
+      (this.apiTokenInfo()?.hasToken ?? false) || !!this.generatedApiToken()
+    );
+  });
   fontFamilyOptions = noteFontFamilyOptions;
   #formInitialized = false;
 
@@ -176,6 +234,11 @@ export class SettingsComponent {
   });
 
   constructor() {
+    this.#userApiService.apiToken().subscribe((apiTokenInfo) => {
+      this.apiTokenInfo.set(apiTokenInfo);
+      this.apiTokenLoading.set(false);
+    });
+
     effect(() => {
       const user = this.user();
 
@@ -205,6 +268,29 @@ export class SettingsComponent {
   resetNoteDefaults() {
     this.form.controls.noteDefaults.setValue(defaultUserSettings.noteDefaults);
     this.saved.set(false);
+  }
+
+  generateApiToken() {
+    this.#userApiService.generateApiToken().subscribe((apiToken) => {
+      this.apiTokenInfo.set({
+        hasToken: true,
+        createdAt: apiToken.createdAt ?? null,
+      });
+      this.generatedApiToken.set(apiToken.token);
+      this.tokenCopied.set(false);
+    });
+  }
+
+  copyGeneratedToken() {
+    const token = this.generatedApiToken();
+
+    if (!token) {
+      return;
+    }
+
+    void navigator.clipboard.writeText(token).then(() => {
+      this.tokenCopied.set(true);
+    });
   }
 
   save() {

--- a/apps/web/src/app/services/user-api.service.ts
+++ b/apps/web/src/app/services/user-api.service.ts
@@ -40,6 +40,14 @@ export class UserApiService {
     return from(this.trpc.user.updateSettings.mutate(settings));
   }
 
+  apiToken() {
+    return from(this.trpc.user.apiToken.query());
+  }
+
+  generateApiToken() {
+    return from(this.trpc.user.generateApiToken.mutate());
+  }
+
   notifications(offset = 0) {
     return from(this.trpc.user.notifications.query({ offset }));
   }

--- a/drizzle/0009_lonely_the_twelve.sql
+++ b/drizzle/0009_lonely_the_twelve.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "accounts" ADD COLUMN "api_token_hash" varchar(64);--> statement-breakpoint
+ALTER TABLE "accounts" ADD COLUMN "api_token_created_at" timestamp;--> statement-breakpoint
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_api_token_hash_unique" UNIQUE("api_token_hash");

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,715 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "eb5f0242-26e8-4505-9db4-1e9690f0cfdd",
+  "prevId": "77e11128-b858-4b21-b5e4-5bbc1465e657",
+  "tables": {
+    "accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picture": {
+          "name": "picture",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token_hash": {
+          "name": "api_token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_token_created_at": {
+          "name": "api_token_created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"noteDefaults\":{\"backgroundColor\":\"#fbb980\",\"textColor\":\"#000000\",\"fontFamily\":\"\\\"Inter\\\", -apple-system, system-ui, sans-serif\",\"bold\":false,\"italic\":false}}'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_email_unique": {
+          "name": "accounts_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "accounts_google_id_unique": {
+          "name": "accounts_google_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["google_id"]
+        },
+        "accounts_api_token_hash_unique": {
+          "name": "accounts_api_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["api_token_hash"]
+        }
+      }
+    },
+    "account_session": {
+      "name": "account_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_session_user_id_accounts_id_fk": {
+          "name": "account_session_user_id_accounts_id_fk",
+          "tableFrom": "account_session",
+          "tableTo": "accounts",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "accounts_boards": {
+      "name": "accounts_boards",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_id": {
+          "name": "private_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "last_accessed_at": {
+          "name": "last_accessed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_boards_account_id_accounts_id_fk": {
+          "name": "accounts_boards_account_id_accounts_id_fk",
+          "tableFrom": "accounts_boards",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_boards_board_id_boards_id_fk": {
+          "name": "accounts_boards_board_id_boards_id_fk",
+          "tableFrom": "accounts_boards",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "accounts_boards_account_id_board_id": {
+          "name": "accounts_boards_account_id_board_id",
+          "columns": ["account_id", "board_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "board_files": {
+      "name": "board_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "board_files_board_id_boards_id_fk": {
+          "name": "board_files_board_id_boards_id_fk",
+          "tableFrom": "board_files",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "boards": {
+      "name": "boards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board": {
+          "name": "board",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "boards_team_id_teams_id_fk": {
+          "name": "boards_team_id_teams_id_fk",
+          "tableFrom": "boards",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(320)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_user_id_accounts_id_fk": {
+          "name": "invitations_user_id_accounts_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_team_id_teams_id_fk": {
+          "name": "invitations_team_id_teams_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_board_id_boards_id_fk": {
+          "name": "invitations_board_id_boards_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitations_inviter_id_accounts_id_fk": {
+          "name": "invitations_inviter_id_accounts_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "accounts",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_team_id_user_id_unique": {
+          "name": "invitations_team_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id", "user_id"]
+        },
+        "invitations_board_id_user_id_unique": {
+          "name": "invitations_board_id_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["board_id", "user_id"]
+        },
+        "invitations_team_id_email_unique": {
+          "name": "invitations_team_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["team_id", "email"]
+        },
+        "invitations_board_id_email_unique": {
+          "name": "invitations_board_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["board_id", "email"]
+        }
+      }
+    },
+    "notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notifications_board_id_boards_id_fk": {
+          "name": "notifications_board_id_boards_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_user_id_accounts_id_fk": {
+          "name": "notifications_user_id_accounts_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "accounts",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "space_boards": {
+      "name": "space_boards",
+      "schema": "",
+      "columns": {
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "space_boards_space_id_spaces_id_fk": {
+          "name": "space_boards_space_id_spaces_id_fk",
+          "tableFrom": "space_boards",
+          "tableTo": "spaces",
+          "columnsFrom": ["space_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "space_boards_board_id_boards_id_fk": {
+          "name": "space_boards_board_id_boards_id_fk",
+          "tableFrom": "space_boards",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "space_boards_space_id_board_id": {
+          "name": "space_boards_space_id_board_id",
+          "columns": ["space_id", "board_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "spaces_team_id_teams_id_fk": {
+          "name": "spaces_team_id_teams_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "starreds": {
+      "name": "starreds",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "board_id": {
+          "name": "board_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "starreds_account_id_accounts_id_fk": {
+          "name": "starreds_account_id_accounts_id_fk",
+          "tableFrom": "starreds",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "starreds_board_id_boards_id_fk": {
+          "name": "starreds_board_id_boards_id_fk",
+          "tableFrom": "starreds",
+          "tableTo": "boards",
+          "columnsFrom": ["board_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "starreds_account_id_board_id": {
+          "name": "starreds_account_id_board_id",
+          "columns": ["account_id", "board_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "team_members": {
+      "name": "team_members",
+      "schema": "",
+      "columns": {
+        "team_id": {
+          "name": "team_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_members_team_id_teams_id_fk": {
+          "name": "team_members_team_id_teams_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "teams",
+          "columnsFrom": ["team_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_members_account_id_accounts_id_fk": {
+          "name": "team_members_account_id_accounts_id_fk",
+          "tableFrom": "team_members",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "team_members_team_id_account_id": {
+          "name": "team_members_team_id_account_id",
+          "columns": ["team_id", "account_id"]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "role": {
+      "name": "role",
+      "values": {
+        "admin": "admin",
+        "member": "member",
+        "guest": "guest"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1782121596868,
       "tag": "0008_first_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "5",
+      "when": 1782382334981,
+      "tag": "0009_lonely_the_twelve",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds personal API tokens to user settings so users can generate or regenerate a token for API access.

## Changes

- Adds API token generation, hashing, storage metadata, and bearer-token authentication on the API.
- Adds a user settings UI section for generating, regenerating, and copying newly issued tokens.
- Adds the database migration for token hash and creation timestamp columns.
- Adds focused API and web tests covering token generation, rotation, bearer auth, and settings reload state.
- Fixes DB startup to await migrations before initializing the client.

## Validation

- `pnpm exec nx test web -- --run src/app/modules/home/components/settings/settings.component.spec.ts`
- `pnpm exec nx typecheck web`
- `pnpm exec nx lint web`
- `pnpm exec nx test api -- --run src/tests/api-users.spec.ts`
- Commit hook: `pnpm test` and `pnpm lint`

`pnpm lint` reports the existing warnings in `apps/web/src/app/modules/board/services/nodes.store.spec.ts` for `no-explicit-any`; no new lint errors were introduced.