### PR TITLE
Add local API-token browser sessions for AI agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,10 @@ POSTGRES_PORT_HOST = 5432
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 
+# Local-development AI screenshot login using a personal API token.
+# The route is unavailable unless NODE_ENV=development.
+AI_AGENT_LOGIN_ENABLED=false
+
 # SMTP configuration for notification emails
 # Replace with your SMTP server credentials
 SMTP_HOST=""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Keep this root guide intentionally small. If new guidance only applies to one ar
 - [Angular And UI](docs/agents/angular-ui.md): Angular, signals, templates, and board UI conventions.
 - [Board Nodes](docs/agents/board-nodes.md): adding or changing board node behavior, validation, persistence, and geometry.
 - [Board Geometry And Arrows](docs/agents/board-geometry-and-arrows.md): coordinate transforms, snapping, arrow attachments, and SVG hit paths.
+- [Local AI Browser Login](docs/agents/local-ai-browser-login.md): development-only API-token exchange for board screenshots and its security boundaries.
 - [Testing](docs/agents/testing.md): project-specific test placement and focused validation commands.
 - [Workflow](docs/agents/workflow.md): formatting, commits, PR expectations, and local development habits.
 

--- a/apps/api/src/app/agent-auth.spec.ts
+++ b/apps/api/src/app/agent-auth.spec.ts
@@ -1,0 +1,153 @@
+import Fastify from 'fastify';
+import fastifyCookie from '@fastify/cookie';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  registerAgentSessionRoute,
+  type AgentAuthEnvironment,
+} from './agent-auth.js';
+
+const enabledEnvironment: AgentAuthEnvironment = {
+  AI_AGENT_LOGIN_ENABLED: 'true',
+  FRONTEND_URL: 'http://localhost:4300',
+  NODE_ENV: 'development',
+};
+
+const user = { id: 'user-1' };
+const apiToken = 'tapiz_pat_a-valid-personal-api-token';
+
+async function createServer(
+  environment: AgentAuthEnvironment,
+  overrides: Partial<Parameters<typeof registerAgentSessionRoute>[1]> = {},
+) {
+  const fastify = Fastify();
+  await fastify.register(fastifyCookie);
+
+  const dependencies = {
+    environment,
+    authenticateApiToken: vi.fn().mockResolvedValue(user),
+    haveBoardAccess: vi.fn().mockResolvedValue(true),
+    createSessionCookie: vi.fn().mockResolvedValue({
+      name: 'auth_session',
+      value: 'session-id',
+      attributes: { httpOnly: true, path: '/', sameSite: 'lax' as const },
+    }),
+    ...overrides,
+  };
+
+  registerAgentSessionRoute(fastify, dependencies);
+  await fastify.ready();
+
+  return { fastify, dependencies };
+}
+
+describe('local agent authentication', () => {
+  it.each([
+    [{ ...enabledEnvironment, AI_AGENT_LOGIN_ENABLED: 'false' }],
+    [{ ...enabledEnvironment, NODE_ENV: 'production' }],
+    [{ ...enabledEnvironment, NODE_ENV: 'test' }],
+    [{ ...enabledEnvironment, NODE_ENV: undefined }],
+  ])(
+    'does not register the route outside safe local configuration',
+    async (env) => {
+      const { fastify } = await createServer(env);
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/api/agent/session',
+      });
+
+      expect(response.statusCode).toBe(404);
+      await fastify.close();
+    },
+  );
+
+  it('rejects an invalid API token', async () => {
+    const { fastify, dependencies } = await createServer(enabledEnvironment, {
+      authenticateApiToken: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/agent/session',
+      headers: { authorization: 'Bearer invalid-token' },
+      payload: {
+        boardId: '4f94614d-7060-42e8-8382-30cc8062e72b',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(dependencies.authenticateApiToken).toHaveBeenCalledWith(
+      'Bearer invalid-token',
+    );
+    expect(dependencies.createSessionCookie).not.toHaveBeenCalled();
+    await fastify.close();
+  });
+
+  it('keeps the selected user subject to existing board permissions', async () => {
+    const { fastify, dependencies } = await createServer(enabledEnvironment, {
+      haveBoardAccess: vi.fn().mockResolvedValue(false),
+    });
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/agent/session',
+      headers: { authorization: `Bearer ${apiToken}` },
+      payload: {
+        boardId: '4f94614d-7060-42e8-8382-30cc8062e72b',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+    expect(dependencies.createSessionCookie).not.toHaveBeenCalled();
+    await fastify.close();
+  });
+
+  it('creates a normal app session for an authorized existing user', async () => {
+    const { fastify, dependencies } = await createServer(enabledEnvironment);
+    const boardId = '4f94614d-7060-42e8-8382-30cc8062e72b';
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/agent/session',
+      headers: { authorization: `Bearer ${apiToken}` },
+      payload: { boardId },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(dependencies.authenticateApiToken).toHaveBeenCalledWith(
+      `Bearer ${apiToken}`,
+    );
+    expect(dependencies.haveBoardAccess).toHaveBeenCalledWith(boardId, user.id);
+    expect(dependencies.createSessionCookie).toHaveBeenCalledWith(user.id);
+    expect(response.cookies).toContainEqual(
+      expect.objectContaining({ name: 'auth_session', value: 'session-id' }),
+    );
+    expect(response.json()).toEqual({
+      boardId,
+      userId: user.id,
+      loginUrl: 'http://localhost:4300/login-redirect',
+      boardUrl:
+        'http://localhost:4300/board/4f94614d-7060-42e8-8382-30cc8062e72b',
+    });
+    await fastify.close();
+  });
+
+  it('rejects requests without an API token', async () => {
+    const { fastify, dependencies } = await createServer(enabledEnvironment, {
+      authenticateApiToken: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const response = await fastify.inject({
+      method: 'POST',
+      url: '/api/agent/session',
+      payload: {
+        boardId: '4f94614d-7060-42e8-8382-30cc8062e72b',
+      },
+    });
+
+    expect(response.statusCode).toBe(401);
+    expect(dependencies.authenticateApiToken).toHaveBeenCalledWith(undefined);
+    expect(dependencies.createSessionCookie).not.toHaveBeenCalled();
+    await fastify.close();
+  });
+});

--- a/apps/api/src/app/agent-auth.ts
+++ b/apps/api/src/app/agent-auth.ts
@@ -1,0 +1,78 @@
+import type { FastifyInstance, FastifyReply } from 'fastify';
+import { z } from 'zod/v4';
+
+export interface AgentAuthEnvironment {
+  [key: string]: string | undefined;
+  AI_AGENT_LOGIN_ENABLED?: string;
+  FRONTEND_URL?: string;
+  NODE_ENV?: string;
+}
+
+interface AgentSessionRouteDependencies {
+  environment: AgentAuthEnvironment;
+  authenticateApiToken: (
+    authorization: string | undefined,
+  ) => Promise<{ id: string } | null | undefined>;
+  haveBoardAccess: (boardId: string, userId: string) => Promise<boolean>;
+  createSessionCookie: (userId: string) => Promise<{
+    name: string;
+    value: string;
+    attributes: Parameters<FastifyReply['setCookie']>[2];
+  }>;
+}
+
+const agentLoginBody = z.object({
+  boardId: z.string().uuid(),
+});
+
+function isLocalAgentLoginEnabled(environment: AgentAuthEnvironment) {
+  return (
+    environment.NODE_ENV?.toLowerCase() === 'development' &&
+    environment.AI_AGENT_LOGIN_ENABLED === 'true'
+  );
+}
+
+export function registerAgentSessionRoute(
+  fastify: FastifyInstance,
+  dependencies: AgentSessionRouteDependencies,
+) {
+  if (!isLocalAgentLoginEnabled(dependencies.environment)) {
+    return;
+  }
+
+  fastify.post('/api/agent/session', async (request, reply) => {
+    reply.header('Cache-Control', 'no-store');
+
+    const user = await dependencies.authenticateApiToken(
+      request.headers.authorization,
+    );
+
+    if (!user) {
+      return reply.status(401).send({ error: 'Unauthorized' });
+    }
+
+    const parsedBody = agentLoginBody.safeParse(request.body);
+    if (!parsedBody.success) {
+      return reply.status(400).send({ error: 'Invalid request' });
+    }
+
+    const { boardId } = parsedBody.data;
+    if (!(await dependencies.haveBoardAccess(boardId, user.id))) {
+      return reply.status(403).send({ error: 'Board access denied' });
+    }
+
+    const sessionCookie = await dependencies.createSessionCookie(user.id);
+    reply.setCookie(
+      sessionCookie.name,
+      sessionCookie.value,
+      sessionCookie.attributes,
+    );
+
+    return reply.send({
+      boardId,
+      userId: user.id,
+      loginUrl: `${dependencies.environment.FRONTEND_URL}/login-redirect`,
+      boardUrl: `${dependencies.environment.FRONTEND_URL}/board/${boardId}`,
+    });
+  });
+}

--- a/apps/api/src/app/app.context.ts
+++ b/apps/api/src/app/app.context.ts
@@ -1,9 +1,9 @@
 import { inferAsyncReturnType } from '@trpc/server';
 import { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
-import { getUser, getUserByApiTokenHash } from './db/user-db.js';
+import { getUser } from './db/user-db.js';
 import { lucia, validateSession } from './auth.js';
 import { FastifyInstance } from 'fastify';
-import { hashApiToken, isApiToken } from './api-token.js';
+import { authenticateApiToken } from './authenticate-api-token.js';
 
 // // prevent angular build errors
 import '@fastify/rate-limit';
@@ -71,19 +71,7 @@ export async function createAuthContext({
   }
 
   async function getUserFromApiToken() {
-    const authorization = req.headers.authorization;
-
-    if (!authorization?.startsWith('Bearer ')) {
-      return null;
-    }
-
-    const token = authorization.slice('Bearer '.length).trim();
-
-    if (!isApiToken(token)) {
-      return null;
-    }
-
-    const dbUser = await getUserByApiTokenHash(hashApiToken(token));
+    const dbUser = await authenticateApiToken(req.headers.authorization);
 
     return toAuthUser(dbUser);
   }

--- a/apps/api/src/app/auth.ts
+++ b/apps/api/src/app/auth.ts
@@ -116,6 +116,12 @@ export async function validateSession(sessionId: string) {
   return lucia.validateSession(sessionId);
 }
 
+export async function createUserSessionCookie(userId: string) {
+  const session = await lucia.createSession(userId, {});
+
+  return lucia.createSessionCookie(session.id);
+}
+
 declare module 'lucia' {
   interface Register {
     Lucia: typeof lucia;

--- a/apps/api/src/app/authenticate-api-token.ts
+++ b/apps/api/src/app/authenticate-api-token.ts
@@ -1,0 +1,13 @@
+import { hashApiToken, isApiToken } from './api-token.js';
+import db from './db/index.js';
+
+export async function authenticateApiToken(authorization?: string) {
+  const match = authorization?.match(/^Bearer\s+(.+)$/i);
+  const token = match?.[1];
+
+  if (!token || !isApiToken(token)) {
+    return undefined;
+  }
+
+  return db.user.getUserByApiTokenHash(hashApiToken(token));
+}

--- a/apps/api/src/app/init-server.ts
+++ b/apps/api/src/app/init-server.ts
@@ -13,10 +13,13 @@ import {
 } from '@trpc/server/adapters/fastify';
 import { Server } from './server.js';
 import { setServer } from './global.js';
-import { getAuthUrl, lucia } from './auth.js';
+import { createUserSessionCookie, getAuthUrl, lucia } from './auth.js';
 import { googleCallback } from './routers/auth-routes.js';
 import { fileUpload } from './file-upload.js';
 import { registerTapizMcp } from './mcp.js';
+import { registerAgentSessionRoute } from './agent-auth.js';
+import { authenticateApiToken } from './authenticate-api-token.js';
+import db from './db/index.js';
 
 const fastify = Fastify({
   logger: false,
@@ -120,6 +123,13 @@ fastify.register(async function (fastify) {
   });
 
   fastify.register(googleCallback);
+
+  registerAgentSessionRoute(fastify, {
+    environment: process.env,
+    authenticateApiToken,
+    haveBoardAccess: db.board.haveAccess,
+    createSessionCookie: createUserSessionCookie,
+  });
 });
 
 const host = process.env['API_HOST'];

--- a/apps/api/src/app/mcp.ts
+++ b/apps/api/src/app/mcp.ts
@@ -15,7 +15,7 @@ import {
 import { Client } from './client.js';
 import type { Server } from './server.js';
 import db from './db/index.js';
-import { hashApiToken, isApiToken } from './api-token.js';
+import { authenticateApiToken } from './authenticate-api-token.js';
 
 type McpUser = {
   id: string;
@@ -165,29 +165,6 @@ function textResult(content: unknown) {
         text: JSON.stringify(content, null, 2),
       },
     ],
-  };
-}
-
-async function authenticateApiToken(
-  authorization: string | undefined,
-): Promise<McpUser | null> {
-  const match = authorization?.match(/^Bearer\s+(.+)$/i);
-  const token = match?.[1];
-
-  if (!token || !isApiToken(token)) {
-    return null;
-  }
-
-  const user = await db.user.getUserByApiTokenHash(hashApiToken(token));
-
-  if (!user) {
-    return null;
-  }
-
-  return {
-    id: user.id,
-    name: user.name,
-    email: user.email,
   };
 }
 

--- a/apps/api/src/app/routers/auth-routes.ts
+++ b/apps/api/src/app/routers/auth-routes.ts
@@ -1,5 +1,9 @@
 import { FastifyInstance } from 'fastify';
-import { getUserInfo, lucia, validateAuthorizationCode } from '../auth.js';
+import {
+  createUserSessionCookie,
+  getUserInfo,
+  validateAuthorizationCode,
+} from '../auth.js';
 import { getUserByGoogleId, updateUser } from '../db/user-db.js';
 import { generateId } from 'lucia';
 import db from '../db/index.js';
@@ -40,8 +44,7 @@ export async function googleCallback(fastify: FastifyInstance) {
         const user = await getUserByGoogleId(googleUser.sub);
         if (user) {
           try {
-            const session = await lucia.createSession(user.id, {});
-            const sessionCookie = lucia.createSessionCookie(session.id);
+            const sessionCookie = await createUserSessionCookie(user.id);
 
             rep.setCookie(sessionCookie.name, sessionCookie.value, {
               ...sessionCookie.attributes,
@@ -71,8 +74,7 @@ export async function googleCallback(fastify: FastifyInstance) {
             googleUser.sub,
           );
 
-          const session = await lucia.createSession(userId, {});
-          const sessionCookie = lucia.createSessionCookie(session.id);
+          const sessionCookie = await createUserSessionCookie(userId);
 
           rep.setCookie(sessionCookie.name, sessionCookie.value, {
             ...sessionCookie.attributes,

--- a/apps/api/src/enviorement.d.ts
+++ b/apps/api/src/enviorement.d.ts
@@ -14,6 +14,7 @@ declare global {
       FRONTEND_URL: string;
       GOOGLE_CLIENT_ID: string;
       GOOGLE_CLIENT_SECRET: string;
+      AI_AGENT_LOGIN_ENABLED?: string;
     }
   }
 }

--- a/docs/agents/local-ai-browser-login.md
+++ b/docs/agents/local-ai-browser-login.md
@@ -1,0 +1,24 @@
+# Local AI Browser Login
+
+Tapiz provides a development-only login endpoint for AI agents that need to
+open a board and take screenshots.
+
+## Security Boundaries
+
+- Keep the route restricted to `NODE_ENV=development`. It must remain
+  unavailable in production even if its feature flag is accidentally enabled.
+- Require `AI_AGENT_LOGIN_ENABLED=true` and authenticate the request with an
+  existing personal API token in the `Authorization: Bearer tapiz_pat_...`
+  header.
+- Use the token owner as the browser identity. Do not accept a user ID or email
+  that would let the caller select a different user.
+- Verify that the token owner already has access to the requested board. Never
+  grant or broaden board, team, or SaaS permissions through this route.
+- Issue the same normal Lucia session cookie used by regular login so all
+  existing authorization checks continue to apply.
+- Never place the API token in a URL, browser storage, or a cookie. Exchange it
+  server-side for the Lucia session cookie.
+
+Use `POST /api/agent/session` to create the session. See the
+[development guide](../dev-guide.md#ai-screenshot-sessions) for configuration,
+the request format, and a Playwright example.

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -32,3 +32,49 @@ Tapiz should now be accessible at `http://localhost:4300/`.
 ## MCP Server
 
 The API exposes a Streamable HTTP MCP server for realtime board automation. See [Tapiz MCP Server](mcp.md) for architecture, token setup, tool behavior, and local connection examples.
+
+## AI screenshot sessions
+
+Local browser agents can create a normal session as an existing Tapiz user
+without completing Google login. Add the following to `.env` and restart the API:
+
+```dotenv
+AI_AGENT_LOGIN_ENABLED=true
+```
+
+The endpoint is registered only when `NODE_ENV=development`, even if the flag
+is enabled. The Docker Compose API uses production mode, so use
+`pnpm start:api` for this workflow.
+
+Generate a personal API token from the Tapiz settings page and save it when it
+is shown. The agent sends that token to request a browser session for one
+board. The token owner must already have access to the board; this feature does
+not bypass board or team authorization. It creates the same Lucia session used
+by regular login, so the browser has the token owner's normal permissions.
+Close the browser context after taking the screenshot.
+
+With Playwright, the browser context's request client shares cookies with its
+pages:
+
+```ts
+const response = await context.request.post('http://localhost:8000/api/agent/session', {
+  headers: {
+    Authorization: `Bearer ${process.env.TAPIZ_API_TOKEN}`,
+  },
+  data: {
+    boardId,
+  },
+});
+
+if (!response.ok()) throw new Error(await response.text());
+
+const { loginUrl, boardUrl } = await response.json();
+await page.goto(loginUrl);
+await page.waitForURL('http://localhost:4300/');
+await page.goto(boardUrl);
+await page.screenshot({ path: 'board.png', fullPage: true });
+```
+
+Send the API token only in the `Authorization` header. Do not put it in a URL,
+browser storage, or a cookie. The endpoint exchanges it server-side for the
+normal Lucia session cookie.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -49,6 +49,11 @@ Authorization: Bearer tapiz_pat_...
 
 The API stores only the token hash. The MCP endpoint hashes incoming tokens and resolves the Tapiz user from `accounts.api_token_hash`.
 
+For local browser screenshots, the same token can be exchanged for a normal
+browser session through the development-only agent login endpoint. See
+[AI screenshot sessions](dev-guide.md#ai-screenshot-sessions). The token owner
+must already have access to the requested board.
+
 ## Tools
 
 ### Board Tools


### PR DESCRIPTION
## Summary

- add a development-only endpoint that exchanges an existing Tapiz personal API token for a normal Lucia browser session
- resolve the token owner through one shared authenticator used by TRPC, MCP, and the browser-session exchange
- require the token owner to already have access to the requested board
- document the Playwright workflow and security boundaries

## Why

AI agents need to open private boards in a real browser to take screenshots. Reusing existing personal API tokens avoids a second agent-specific secret and prevents arbitrary user selection.

## Impact

The endpoint is registered only when `NODE_ENV=development` and `AI_AGENT_LOGIN_ENABLED=true`. Production authentication and authorization remain unchanged. The API token is accepted only through the Authorization header and is exchanged server-side for the normal Lucia cookie.

## Validation

- `pnpm exec nx typecheck api --skip-nx-cache`
- `pnpm exec nx test api -- --run src/app/agent-auth.spec.ts src/app/mcp.spec.ts`
- `pnpm e2e:tests`
- commit hooks: full non-API tests and repository lint